### PR TITLE
EventMap, Interactable, and much more

### DIFF
--- a/Camera.cpp
+++ b/Camera.cpp
@@ -116,20 +116,26 @@ void Camera::panTo(string thingName) {
     GhostFocus::create(c->focus, thingName);
 }
 
-void Camera::fadeIn(int m) {
-    if(c->fadeStatus == FxStatus::unapplied) {
-        c->fadeMultiplier = m;
-        c->fadeStatus = FxStatus::applying;
-        c->fadeStart = frameCount;
-    }
-}
-
-void Camera::fadeOut(int m) {
+int Camera::fadeIn(int m) {
+    if(c->fadeStatus == unapplied)
+        return 1;
     if(c->fadeStatus == FxStatus::applied) {
         c->fadeMultiplier = m;
         c->fadeStatus = FxStatus::unapplying;
         c->fadeStart = frameCount;
     }
+    return 0;
+}
+
+int Camera::fadeOut(int m) {
+    if(c->fadeStatus == applied)
+        return 1;
+    if(c->fadeStatus == FxStatus::unapplied) {
+        c->fadeMultiplier = m;
+        c->fadeStatus = FxStatus::applying;
+        c->fadeStart = frameCount;
+    }
+    return 0;
 }
 
 void Camera::warpIn(int m) {

--- a/Camera.cpp
+++ b/Camera.cpp
@@ -1,7 +1,5 @@
 #include "./Camera.h"
-#include <iostream>
-#include "globals.h"
-#include "./things/GhostFocus.h"
+
 
 
 using namespace std;

--- a/Camera.h
+++ b/Camera.h
@@ -7,8 +7,10 @@
 #include <fstream>
 #include <string>
 #include "globals.h"
-#include "./things/Thing.h"
 #include "utils.h"
+#include "./things/Thing.h"
+#include "./things/GhostFocus.h"
+#include "./components/Sprite.h"
 
 using namespace std;
 

--- a/Camera.h
+++ b/Camera.h
@@ -61,8 +61,8 @@ class Camera {
 
         static int parse_camera(ifstream &mapData);
         static void panTo(string thingName);
-        static void fadeIn(int m);
-        static void fadeOut(int m);
+        static int fadeIn(int m);
+        static int fadeOut(int m);
         static void warpIn(int m);
         static void warpOut(int m);
         static string getFocusName();

--- a/Event.cpp
+++ b/Event.cpp
@@ -14,11 +14,13 @@ Event::~Event() {
 
 void Event::addNode(EventNode* node) {
     nodes.push_back(node);
+
+    // Maybe we shouldn't do this every time. There's a refactor here.
+    firstNode = nodes.front();
+    current = firstNode;
 }
 
-
 void Event::begin() {
-    current = nodes.front();
     stage = EventStage::enterNode;
     setBeginGameState();
 }
@@ -65,7 +67,9 @@ void Event::meat(KeyPresses keysDown) {
             break;
         case (EventStage::terminateEvent):
             event->setEndGameState();
-            delete event;
+            event->current = event->firstNode;
+            event->stage = EventStage::pending;
+            // delete event;
             break;
     }
 }

--- a/Event.h
+++ b/Event.h
@@ -24,6 +24,7 @@ struct Event {
     Event();
     ~Event();
 
+    EventNode* firstNode;
     vector<EventNode*> nodes;
     void addNode(EventNode* node);
 

--- a/EventNode.cpp
+++ b/EventNode.cpp
@@ -21,6 +21,7 @@ int EventNode::hold (KeyPresses keysDown) {
     if(phrase == nullptr) 
         return 1;
     if(phrase->isComplete()) {
+        phrase->reset();
         UIRenderer::removePhrase(phrase);
         return 1;
     }

--- a/EventNode.cpp
+++ b/EventNode.cpp
@@ -9,6 +9,7 @@ EventNode::EventNode(EventNode **nn, Phrase *ph, int (*ent)(void), int (*ex)(voi
 {};
 
 EventNode::~EventNode() {
+    delete nextNode;
     delete phrase;
 }
 

--- a/EventNode.cpp
+++ b/EventNode.cpp
@@ -18,7 +18,7 @@ void EventNode::loadPhrase() {
 }
 
 int EventNode::hold (KeyPresses keysDown) {
-    if(phrase == nullptr)
+    if(phrase == nullptr) 
         return 1;
     if(phrase->isComplete()) {
         UIRenderer::removePhrase(phrase);

--- a/EventNode.cpp
+++ b/EventNode.cpp
@@ -18,6 +18,8 @@ void EventNode::loadPhrase() {
 }
 
 int EventNode::hold (KeyPresses keysDown) {
+    if(phrase == nullptr)
+        return 1;
     if(phrase->isComplete()) {
         UIRenderer::removePhrase(phrase);
         return 1;

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 timtest:
-	g++ -o bary -I . -I ./components *.cpp components/*.cpp things/*.cpp gui/*.cpp   -I include -L lib -l SDL2-2.0.0 -lSDL2_image -std=c++17
+	g++ -o bary -I . -I ./components *.cpp components/*.cpp things/*.cpp gui/*.cpp events/*.cpp   -I include -L lib -l SDL2-2.0.0 -lSDL2_image -std=c++17

--- a/components/Collidable.cpp
+++ b/components/Collidable.cpp
@@ -4,13 +4,13 @@
 
 using namespace std;
 
-Collidable::Collidable (int &x, int &y, string &tN, CollidableData cd) : 
-x(x), 
-y(y), 
-thingName(tN),
+Collidable::Collidable (Thing *parent, CollidableData cd) : 
 layer(cd.layer),
 rays(cd.rays),
-active(true) {}
+active(true),
+x(parent->position.x),
+y(parent->position.y),
+thingName(parent->name) {}
 
 Collidable::~Collidable() {
     for (auto r : rays) {

--- a/components/Collidable.h
+++ b/components/Collidable.h
@@ -1,6 +1,7 @@
 #ifndef COLLIDABLE_H
 #define COLLIDABLE_H
 #include "Ray.h"
+#include "../things/Thing.h"
 #include <vector>
 #include <string>
 #include <fstream>
@@ -14,7 +15,7 @@ struct CollidableData {
 
 class Collidable {
     public:
-        Collidable(int &x, int &y, string &tN, CollidableData cd);
+        Collidable(Thing *parent, CollidableData cd);
         ~Collidable();
         bool active;
         int &x, &y, layer;

--- a/components/Interactable.cpp
+++ b/components/Interactable.cpp
@@ -1,0 +1,26 @@
+#include "./Interactable.h"
+
+
+Interactable::Interactable(Thing* parent, CollidableData cd, Event* e) : Collidable(parent,cd) {
+    event = e;
+    Interactable::interactables[currentID++] = this;
+}
+
+Interactable::~Interactable() {
+    interactables.erase(id);
+}
+
+// STATIC
+
+int Interactable::currentID = 0;
+
+int Interactable::checkForInteractables(Ray &incoming, int layer) {
+    for (auto const& [id, o] : Interactable::interactables){
+        if(o->isColliding(incoming, layer)) {
+            if(o->event)
+                o->event->begin();
+            return 1;
+        }
+    }
+    return 0;
+}

--- a/components/Interactable.h
+++ b/components/Interactable.h
@@ -1,0 +1,20 @@
+#ifndef INTERACTABLE_H
+#define INTERACTABLE_H
+#include "./Collidable.h"
+#include "Event.h"
+#include <map>
+
+class Interactable : public Collidable {
+    public:
+        Interactable(Thing* parent, CollidableData cd, Event *e = nullptr);
+        ~Interactable();
+        int id;
+
+        Event* event;
+
+        static int currentID;
+        inline static map<int, Interactable*> interactables;
+        static int checkForInteractables(Ray &incoming, int layer);
+};
+
+#endif

--- a/components/Obstruction.cpp
+++ b/components/Obstruction.cpp
@@ -1,9 +1,8 @@
 #include "./Obstruction.h"
 
 
-Obstruction::Obstruction(int &x, int &y, string &tN, CollidableData cd) : Collidable(x,y,tN,cd) {
-    id = currentID++;
-    Obstruction::obstructions[id] = this;
+Obstruction::Obstruction(Thing *parent, CollidableData cd) : Collidable(parent,cd) {
+    Obstruction::obstructions[currentID++] = this;
 }
 
 Obstruction::~Obstruction() {
@@ -14,11 +13,11 @@ Obstruction::~Obstruction() {
 
 int Obstruction::currentID = 0;
 
-bool Obstruction::checkForObstructions(Ray &incoming, int layer) {
+int Obstruction::checkForObstructions(Ray &incoming, int layer) {
     for (auto const& [id, o] : Obstruction::obstructions){
         if(o->isColliding(incoming, layer)) {
-            return true;
+            return 1;
         }
     }
-    return false;
+    return 0;
 }

--- a/components/Obstruction.h
+++ b/components/Obstruction.h
@@ -5,13 +5,13 @@
 
 class Obstruction : public Collidable {
     public:
-        Obstruction(int &x, int &y, string &tN, CollidableData cd);
+        Obstruction(Thing *parent, CollidableData cd);
         ~Obstruction();
         int id;
 
         static int currentID;
         inline static map<int, Obstruction*> obstructions;
-        static bool checkForObstructions(Ray &incoming, int layer);
+        static int checkForObstructions(Ray &incoming, int layer);
 };
 
 #endif

--- a/components/SimpleMessageI.cpp
+++ b/components/SimpleMessageI.cpp
@@ -14,12 +14,18 @@ int test_event_node_callback () {
         return 1;
     };
 
+int test_standlone_message_callback() {
+        Phrase *ph = new Phrase(Point(300,200), 150, 40, 1, ScrollType::continuous, "Another scrolling phrase that will just continue on for a while and then eventually it will destroy itself", 3, true);
+        UIRenderer::addPhrase(ph);
+        return 1;
+    };
+
 
 SimpleMessageI::SimpleMessageI(Thing* parent, string message, CollidableData cd) : Interactable(parent, cd) {
-    Phrase *ph = new Phrase(Point(100,100), 150, 40, 1, ScrollType::continuous, "What's that??`Is something up and to my right? I'd better go check this shit out.");
+    Phrase *ph = new Phrase(Point(100,100), 150, 40, 1, ScrollType::continuous, "What's that??`Is something up and to my right? I'd better go check this shit out.", 2);
     Phrase *ph2 = new Phrase(Point(200,150), 300, 24, 2, ScrollType::allButLast, "Damn, nothing.");
     EventNode *node = new EventNode(&node2, ph, &test_event_node_callback, &test_event_node_callback);
-    node2 = new EventNode(NULL, ph2, &test_event_node_callback);
+    node2 = new EventNode(NULL, ph2, &test_event_node_callback, &test_standlone_message_callback);
     event = new Event();
     event->addNode(node);
     event->addNode(node2);

--- a/components/SimpleMessageI.cpp
+++ b/components/SimpleMessageI.cpp
@@ -22,7 +22,7 @@ int test_standlone_message_callback() {
 
 
 SimpleMessageI::SimpleMessageI(Thing* parent, string message, CollidableData cd) : Interactable(parent, cd) {
-    Phrase *ph = new Phrase(Point(100,100), 150, 40, 1, ScrollType::continuous, "What's that??`Is something up and to my right? I'd better go check this shit out.", 2);
+    Phrase *ph = new Phrase(Point(100,100), 300, 40, 1, ScrollType::continuous, "What's that??`Is something up and to my right? I'd better go check this shit out. What's that?? Is something up and to my right? I'd better go check this shit out. What's that?? Is something up and to my right? I'd better go check this shit out. What's that?? Is something up and to my right? I'd better go check this shit out.", 4);
     Phrase *ph2 = new Phrase(Point(200,150), 300, 24, 2, ScrollType::allButLast, "Damn, nothing.");
     EventNode *node = new EventNode(&node2, ph, &test_event_node_callback, &test_event_node_callback);
     node2 = new EventNode(NULL, ph2, &test_event_node_callback, &test_standlone_message_callback);

--- a/components/SimpleMessageI.cpp
+++ b/components/SimpleMessageI.cpp
@@ -1,35 +1,7 @@
 #include "./SimpleMessageI.h"
 
-int test_event_node_callback () {
-        Timer::startOrIgnore("test");
-        DirectionMap dM;
-        int time = Timer::timeSince("test");
-        if(time < 60) {
-            if (time > 30)
-                dM.right = true;
-            dM.down = true;
-            FieldPlayer::player->walk->move(dM);
-            return 0;
-        }
-        Timer::destroy("test");
-        return 1;
-    };
-
-int test_standlone_message_callback() {
-        Phrase *ph = new Phrase(Point(300,200), 150, 40, 1, ScrollType::continuous, "Another scrolling phrase that will just continue on for a while and then eventually it will destroy itself", 3, true);
-        UIRenderer::addPhrase(ph);
-        return 1;
-    };
-
-
 SimpleMessageI::SimpleMessageI(Thing* parent, string message, CollidableData cd) : Interactable(parent, cd) {
-    Phrase *ph = new Phrase(Point(100,100), 300, 70, 1, ScrollType::continuous, "What's that??`Is something up and to my right? I'd better go check this shit out.``What's that??`Is something up and to my right? I'd better go check this shit out.``What's that??`Is something up and to my right? I'd better go check this shit out.``What's that??`Is something up and to my right? I'd better go check this shit out.", 2);
-    Phrase *ph2 = new Phrase(Point(200,150), 300, 24, 2, ScrollType::allButLast, "Damn, nothing.");
-    EventNode *node = new EventNode(&node2, ph, &test_event_node_callback, &test_event_node_callback);
-    node2 = new EventNode(NULL, ph2, &test_event_node_callback, &test_standlone_message_callback);
-    event = new Event();
-    event->addNode(node);
-    event->addNode(node2);
+
 }
 
 SimpleMessageI::~SimpleMessageI() {

--- a/components/SimpleMessageI.cpp
+++ b/components/SimpleMessageI.cpp
@@ -1,0 +1,27 @@
+#include "./SimpleMessageI.h"
+
+int test_event_node_callback () {
+        Timer::startOrIgnore("test");
+        DirectionMap dM;
+        if(Timer::timeSince("test") < 60) {
+            if (frameCount > 350)
+                dM.right = true;
+            dM.down = true;
+            FieldPlayer::player->walk->move(dM);
+            return 0;
+        }
+        Timer::destroy("test");
+        return 1;
+    };
+
+
+SimpleMessageI::SimpleMessageI(Thing* parent, string message, CollidableData cd) : Interactable(parent, cd) {
+    Phrase *ph = new Phrase(Point(200,200), 100, 40, 1, ScrollType::allButLast, "Testing an interactable.");
+    EventNode *node =  new EventNode(nullptr, ph, nullptr, &test_event_node_callback);
+    event = new Event();
+    event->addNode(node);
+}
+
+SimpleMessageI::~SimpleMessageI() {
+    interactables.erase(id);
+}

--- a/components/SimpleMessageI.cpp
+++ b/components/SimpleMessageI.cpp
@@ -16,10 +16,13 @@ int test_event_node_callback () {
 
 
 SimpleMessageI::SimpleMessageI(Thing* parent, string message, CollidableData cd) : Interactable(parent, cd) {
-    Phrase *ph = new Phrase(Point(200,200), 100, 40, 1, ScrollType::allButLast, "Testing an interactable.");
-    EventNode *node =  new EventNode(nullptr, ph, nullptr, &test_event_node_callback);
+    Phrase *ph = new Phrase(Point(100,100), 150, 40, 1, ScrollType::continuous, "What's that??`Is something up and to my right? I'd better go check this shit out.");
+    Phrase *ph2 = new Phrase(Point(200,150), 300, 24, 2, ScrollType::allButLast, "Damn, nothing.");
+    EventNode *node = new EventNode(&node2, ph, &test_event_node_callback, &test_event_node_callback);
+    node2 = new EventNode(NULL, ph2, &test_event_node_callback);
     event = new Event();
     event->addNode(node);
+    event->addNode(node2);
 }
 
 SimpleMessageI::~SimpleMessageI() {

--- a/components/SimpleMessageI.cpp
+++ b/components/SimpleMessageI.cpp
@@ -3,8 +3,9 @@
 int test_event_node_callback () {
         Timer::startOrIgnore("test");
         DirectionMap dM;
-        if(Timer::timeSince("test") < 60) {
-            if (frameCount > 350)
+        int time = Timer::timeSince("test");
+        if(time < 60) {
+            if (time > 30)
                 dM.right = true;
             dM.down = true;
             FieldPlayer::player->walk->move(dM);
@@ -22,7 +23,7 @@ int test_standlone_message_callback() {
 
 
 SimpleMessageI::SimpleMessageI(Thing* parent, string message, CollidableData cd) : Interactable(parent, cd) {
-    Phrase *ph = new Phrase(Point(100,100), 300, 40, 1, ScrollType::continuous, "What's that??`Is something up and to my right? I'd better go check this shit out. What's that?? Is something up and to my right? I'd better go check this shit out. What's that?? Is something up and to my right? I'd better go check this shit out. What's that?? Is something up and to my right? I'd better go check this shit out.", 4);
+    Phrase *ph = new Phrase(Point(100,100), 300, 70, 1, ScrollType::continuous, "What's that??`Is something up and to my right? I'd better go check this shit out.``What's that??`Is something up and to my right? I'd better go check this shit out.``What's that??`Is something up and to my right? I'd better go check this shit out.``What's that??`Is something up and to my right? I'd better go check this shit out.", 2);
     Phrase *ph2 = new Phrase(Point(200,150), 300, 24, 2, ScrollType::allButLast, "Damn, nothing.");
     EventNode *node = new EventNode(&node2, ph, &test_event_node_callback, &test_event_node_callback);
     node2 = new EventNode(NULL, ph2, &test_event_node_callback, &test_standlone_message_callback);

--- a/components/SimpleMessageI.h
+++ b/components/SimpleMessageI.h
@@ -10,6 +10,9 @@ class SimpleMessageI : public Interactable {
     public:
         SimpleMessageI(Thing *parent, string message, CollidableData cd);
         ~SimpleMessageI();
+
+        // This is a hack to keep this pointer from going out of scope in the event, we should have a better way
+        EventNode *node2;
 };
 
 #endif

--- a/components/SimpleMessageI.h
+++ b/components/SimpleMessageI.h
@@ -1,18 +1,14 @@
 #ifndef SIMPLE_MESSAGE_I_H
 #define SIMPLE_MESSAGE_I_H
-#include "./Interactable.h"
 #include "Event.h"
 #include "Timer.h"
+#include "./Interactable.h"
 #include "../things/FieldPlayer.h"
-#include <map>
 
 class SimpleMessageI : public Interactable {
     public:
         SimpleMessageI(Thing *parent, string message, CollidableData cd);
         ~SimpleMessageI();
-
-        // This is a hack to keep this pointer from going out of scope in the event, we should have a better way
-        EventNode *node2;
 };
 
 #endif

--- a/components/SimpleMessageI.h
+++ b/components/SimpleMessageI.h
@@ -1,0 +1,15 @@
+#ifndef SIMPLE_MESSAGE_I_H
+#define SIMPLE_MESSAGE_I_H
+#include "./Interactable.h"
+#include "Event.h"
+#include "Timer.h"
+#include "../things/FieldPlayer.h"
+#include <map>
+
+class SimpleMessageI : public Interactable {
+    public:
+        SimpleMessageI(Thing *parent, string message, CollidableData cd);
+        ~SimpleMessageI();
+};
+
+#endif

--- a/components/Walk.cpp
+++ b/components/Walk.cpp
@@ -10,18 +10,18 @@ void Walk::padSide(DirectionMap dM) {
     int xCenter = x + (sourceRect.w / 2);
     int yBottom = y + sourceRect.h;
     if (dM.up || dM.down){
-        ray = Ray(xCenter, yBottom, xCenter - 7, yBottom);
+        ray = Ray(xCenter, yBottom, xCenter - 5, yBottom);
         if(Obstruction::checkForObstructions(ray, layer)) 
             x += 1;
-        ray = Ray(xCenter, yBottom, xCenter + 7, yBottom);
+        ray = Ray(xCenter, yBottom, xCenter + 5, yBottom);
         if(Obstruction::checkForObstructions(ray, layer)) 
             x -= 1;
     }
     if(dM.left || dM.right) {
-        ray = Ray(xCenter, yBottom, xCenter, yBottom - 7);
+        ray = Ray(xCenter, yBottom, xCenter, yBottom - 5);
         if(Obstruction::checkForObstructions(ray, layer)) 
             y += 1;
-        ray = Ray(xCenter, yBottom, xCenter, yBottom + 7);
+        ray = Ray(xCenter, yBottom, xCenter, yBottom + 5);
         if(Obstruction::checkForObstructions(ray, layer)) 
             y -= 1;
     }
@@ -34,16 +34,16 @@ bool Walk::checkCollision(Direction d) {
     int yBottom = y + sourceRect.h;
     switch(d){
         case (Direction::up):
-            ray = Ray(xCenter, yBottom, xCenter, yBottom - 8);
+            ray = Ray(xCenter, yBottom, xCenter, yBottom - 6);
             break;
         case (Direction::down):
-            ray = Ray(xCenter, yBottom, xCenter, yBottom + 8);
+            ray = Ray(xCenter, yBottom, xCenter, yBottom + 6);
             break;
         case (Direction::left):
-            ray = Ray(xCenter, yBottom, xCenter - 8, yBottom);
+            ray = Ray(xCenter, yBottom, xCenter - 6, yBottom);
             break;
         case (Direction::right):
-            ray = Ray(xCenter, yBottom, xCenter + 8, yBottom);
+            ray = Ray(xCenter, yBottom, xCenter + 6, yBottom);
             break;
         default:
             return false;

--- a/components/Walk.cpp
+++ b/components/Walk.cpp
@@ -98,16 +98,16 @@ void Walk::face(Direction d) {
     };
 }
 
-void Walk::move(DirectionMap dM){
+Direction Walk::move(DirectionMap dM){
     Direction d = directionFromMap(dM);
     face(d);
     if (speed == 0) {
         sourceRect.x = 0;
-        return;
+        return d;
     }
     if (speed < 3 && frameCount % (3 - speed) != 0) {
         animate(d);
-        return;
+        return d;
     }
 
     int appliedSpeed = speed < 4 ? 1 : speed;
@@ -137,6 +137,7 @@ void Walk::move(DirectionMap dM){
             x = x + appliedSpeed;
     }
     animate(directionFromMap(dM));
+    return d;
 };
 
 void Walk::changeSpeed(bool decrease) {

--- a/components/Walk.h
+++ b/components/Walk.h
@@ -18,7 +18,7 @@ class Walk {
         bool checkCollision(Direction d);
         void animate(Direction d);
         void face(Direction d);
-        void move(DirectionMap dM);
+        Direction move(DirectionMap dM);
         void changeSpeed(bool decrease);
 };
 

--- a/events/burgEvents.cpp
+++ b/events/burgEvents.cpp
@@ -18,5 +18,5 @@ void burgEvents::sailor_shack_test() {
     Ray *ray = new Ray(117,253,173,253);
     cd.rays.push_back(ray);
     cd.layer = 0;
-    Interactable *smi = new Interactable(ss, cd, event);
+    new Interactable(ss, cd, event);
 }

--- a/events/burgEvents.cpp
+++ b/events/burgEvents.cpp
@@ -1,0 +1,22 @@
+#include "./burgEvents.h"
+
+void burgEvents::sailor_shack_test() {
+    Phrase *ph = new Phrase(Point(100,100), 300, 70, 1, ScrollType::continuous, "What's that??``Is something up and to my right? I'd better go check this shit out.`I say again..``What's that??``Is something up and to my right? I'd better go check this shit out.", 2);
+    Phrase *ph2 = new Phrase(Point(200,150), 300, 24, 2, ScrollType::allButLast, "Damn, nothing.");
+
+    EventNode *node;
+    EventNode **node2pointer = new EventNode*;
+    *node2pointer = new EventNode(nullptr, ph2, &testActions::test_event_node_callback, &testActions::test_standlone_message_callback);
+    node = new EventNode(node2pointer, ph, &testActions::test_event_node_callback, &testActions::test_event_node_callback);
+
+    Event *event = new Event();
+    event->addNode(node);
+    event->addNode(*node2pointer);
+
+    Building* ss = Building::find_building("Sailor Shack");
+    CollidableData cd;
+    Ray *ray = new Ray(117,253,173,253);
+    cd.rays.push_back(ray);
+    cd.layer = 0;
+    Interactable *smi = new Interactable(ss, cd, event);
+}

--- a/events/burgEvents.h
+++ b/events/burgEvents.h
@@ -1,0 +1,12 @@
+#ifndef BURG_EVENTS_H
+#define BURG_EVENTS_H
+#include "./eventActions.h"
+#include "things/Building.h"
+#include "components/Interactable.h"
+#include "Ray.h"
+
+namespace burgEvents {
+    void sailor_shack_test();
+};
+
+#endif

--- a/events/eventActions.cpp
+++ b/events/eventActions.cpp
@@ -1,0 +1,22 @@
+#include "eventActions.h"
+
+int testActions::test_event_node_callback () {
+    Timer::startOrIgnore("test");
+    DirectionMap dM;
+    int time = Timer::timeSince("test");
+    if(time < 60) {
+        if (time > 30)
+            dM.right = true;
+        dM.down = true;
+        FieldPlayer::player->walk->move(dM);
+        return 0;
+    }
+    Timer::destroy("test");
+    return 1;
+};
+
+int testActions::test_standlone_message_callback() {
+    Phrase *ph = new Phrase(Point(300,200), 150, 40, 1, ScrollType::continuous, "Another scrolling phrase that will just continue on for a while and then eventually it will destroy itself", 3, true);
+    UIRenderer::addPhrase(ph);
+    return 1;
+};

--- a/events/eventActions.h
+++ b/events/eventActions.h
@@ -1,0 +1,13 @@
+#ifndef EVENT_ACTIONS_H
+#define EVENT_ACTIONS_H
+#include "Timer.h"
+#include "Ray.h"
+#include "things/FieldPlayer.h"
+#include "gui/Phrase.h"
+
+namespace testActions {
+    int test_event_node_callback ();
+    int test_standlone_message_callback();
+};
+
+#endif

--- a/events/eventMap.cpp
+++ b/events/eventMap.cpp
@@ -1,0 +1,12 @@
+#include "eventMap.h"
+
+void eventMap::initialize() {
+    eventMap::mapping["Burg"].push_back(&burgEvents::sailor_shack_test);
+};
+
+void eventMap::load_events(string key) {
+    vector<void (*)()> events = eventMap::mapping[key];
+    for (auto f : events) {
+        f();
+    }
+};

--- a/events/eventMap.h
+++ b/events/eventMap.h
@@ -1,0 +1,16 @@
+#ifndef EVENT_MAP_H
+#define EVENT_MAP_H
+#include <map>
+#include <vector>
+#include <string>
+#include "./burgEvents.h"
+
+using namespace std;
+
+namespace eventMap {
+    inline map<string, vector<void (*)()>> mapping;
+    void initialize();
+    void load_events(string key);
+};
+
+#endif

--- a/gui/Phrase.cpp
+++ b/gui/Phrase.cpp
@@ -47,6 +47,13 @@ Phrase::Phrase(Point p, int pixelWidth, int pixelHeight, int scale, ScrollType t
                 )) {
                 lastSpace = i;
             }
+            // Manual new line with ` char (needs work for multiple)
+            if (int(text[i]) == 96) {
+                linesRef->push(text.substr(lineFirstCharIndex, i));
+                i++;
+                lineFirstCharIndex = i;
+                continue;
+            }
             // Ran out of room for line
             if (i > 0 && i - lineFirstCharIndex == letterLength) {
                 // Ran out of lines that will fit

--- a/gui/Phrase.cpp
+++ b/gui/Phrase.cpp
@@ -9,11 +9,7 @@ inline constexpr int LETTERS_PER_FONT_ROW = 24;
 Phrase::Phrase(Point p, int pixelWidth, int pixelHeight, int scale, ScrollType type, string t) : 
     position(p),
     phraseScale(scale), 
-    scrollType(type), 
-    progStart(-1),
-    advanceStart(-1),
-    fullyDisplayed(false),
-    complete(false) {
+    scrollType(type) {
     box = SDL_Rect { position.x, position.y, pixelWidth, pixelHeight };
     if (!font) {
         SDL_Surface* temp = IMG_Load("assets/fonts/paryfont4rows.png");
@@ -23,7 +19,10 @@ Phrase::Phrase(Point p, int pixelWidth, int pixelHeight, int scale, ScrollType t
     letterLength = (pixelWidth / scale) / 8;
     letterHeight = (pixelHeight / scale) / 12;
     text = t;
+    reset();
+}
 
+void Phrase::reset() {
     // Very happy case: all text fits on one line
     if (text.length() <= letterLength)
         lines.push(text);
@@ -96,6 +95,10 @@ Phrase::Phrase(Point p, int pixelWidth, int pixelHeight, int scale, ScrollType t
         }
     }
     totalLines = lines.size() + hiddenLines.size();
+    progStart = -1;
+    advanceStart = -1;
+    fullyDisplayed = false;
+    complete = false;
 }
 
 void Phrase::advance() {

--- a/gui/Phrase.cpp
+++ b/gui/Phrase.cpp
@@ -147,8 +147,11 @@ int Phrase::progDisplay() {
         else
             occlusion = 0;
         for (j = 0; j < line.size(); j++) {
-            if (charsToDisplay < 1)
+            if (charsToDisplay < 1){
+                if(advanceProgress >= LETTER_HEIGHT)
+                    advanceStart++;
                 return 1;
+            }
             renderLetter(i, j, line[j], occlusion, advanceProgress);
             charsToDisplay--;
             total++;

--- a/gui/Phrase.cpp
+++ b/gui/Phrase.cpp
@@ -50,7 +50,7 @@ void Phrase::reset() {
             }
             // Manual new line with ` char (needs work for multiple)
             if (int(text[i]) == 96) {
-                linesRef->push(text.substr(lineFirstCharIndex, i));
+                linesRef->push(text.substr(lineFirstCharIndex, i - lineFirstCharIndex));
                 i++;
                 lineFirstCharIndex = i;
                 continue;

--- a/gui/Phrase.cpp
+++ b/gui/Phrase.cpp
@@ -48,10 +48,15 @@ void Phrase::reset() {
                 )) {
                 lastSpace = i;
             }
-            // Manual new line with ` char (needs work for multiple)
+            // Manual new line with ` char
             if (int(text[i]) == 96) {
                 linesRef->push(text.substr(lineFirstCharIndex, i - lineFirstCharIndex));
+                if (!bonusTime && linesRef->size() >= letterHeight - 1) {
+                    bonusTime = true;
+                    linesRef = &hiddenLines;
+                }
                 i++;
+                lastSpace = i;
                 lineFirstCharIndex = i;
                 continue;
             }

--- a/gui/Phrase.cpp
+++ b/gui/Phrase.cpp
@@ -102,7 +102,7 @@ void Phrase::reset() {
 }
 
 void Phrase::advance() {
-    if(!fullyDisplayed)
+    if(!fullyDisplayed || advanceStart > 0)
         return;
     if (hiddenLines.size() < 1) {
         while(!lines.empty()) lines.pop();

--- a/gui/Phrase.cpp
+++ b/gui/Phrase.cpp
@@ -6,10 +6,12 @@ inline constexpr int LETTER_WIDTH = 8;
 inline constexpr int LETTER_HEIGHT = 12;
 inline constexpr int LETTERS_PER_FONT_ROW = 24;
 
-Phrase::Phrase(Point p, int pixelWidth, int pixelHeight, int scale, ScrollType type, string t) : 
+Phrase::Phrase(Point p, int pixelWidth, int pixelHeight, int scale, ScrollType type, string t, int d, bool aD) : 
     position(p),
     phraseScale(scale), 
-    scrollType(type) {
+    scrollType(type),
+    delay(d),
+    autoDestroy(aD) {
     box = SDL_Rect { position.x, position.y, pixelWidth, pixelHeight };
     if (!font) {
         SDL_Surface* temp = IMG_Load("assets/fonts/paryfont4rows.png");
@@ -117,7 +119,7 @@ bool Phrase::isComplete() {
 }
 
 /* TODO: This breaks if the pixelWidth value is above about 220 * scale. Need to fix */
-int Phrase::progDisplay(int delay) {
+int Phrase::progDisplay() {
     if(complete)
         return 0;
     SDL_SetRenderDrawColor(renderer, 100,100,255,255);

--- a/gui/Phrase.cpp
+++ b/gui/Phrase.cpp
@@ -51,7 +51,7 @@ void Phrase::reset() {
             // Manual new line with ` char
             if (int(text[i]) == 96) {
                 linesRef->push(text.substr(lineFirstCharIndex, i - lineFirstCharIndex));
-                if (!bonusTime && linesRef->size() >= letterHeight - 1) {
+                if (!bonusTime && linesRef->size() > letterHeight) {
                     bonusTime = true;
                     linesRef = &hiddenLines;
                 }

--- a/gui/Phrase.h
+++ b/gui/Phrase.h
@@ -35,6 +35,7 @@ class Phrase {
         bool isComplete();
 
         int progDisplay(int delay);
+        void reset();
 
 
         static SDL_Texture *font;

--- a/gui/Phrase.h
+++ b/gui/Phrase.h
@@ -18,23 +18,23 @@ enum ScrollType {
 // We should probably also have a SimplePhrase class
 class Phrase {
     public:
-        int letterLength, letterHeight, phraseScale;
+        int letterLength, letterHeight, phraseScale, delay;
         int progStart, advanceStart, totalLines;
         bool fullyDisplayed;
         bool complete;
+        bool autoDestroy;
         ScrollType scrollType;
         Point position;
         SDL_Rect box;
         string text;
-        queue<string> lines;
-        queue<string> hiddenLines;
+        queue<string> lines, hiddenLines;
 
-        Phrase(Point o, int pixelWidth, int pixelHeight, int pS, ScrollType type, string t);
+        Phrase(Point o, int pixelWidth, int pixelHeight, int pS, ScrollType type, string t, int d = 1, bool aD = false);
 
         void advance();
         bool isComplete();
 
-        int progDisplay(int delay);
+        int progDisplay();
         void reset();
 
 

--- a/gui/UIRenderer.cpp
+++ b/gui/UIRenderer.cpp
@@ -8,8 +8,17 @@ void UIRenderer::addPhrase(Phrase *p) {
 };
 
 void UIRenderer::renderPhrases() {
-    for (auto p : u->phrases)
-        p->progDisplay(1);
+   vector<Phrase*>::iterator itr = u->phrases.begin();
+   while (itr != u->phrases.end()) {
+        Phrase* p = *itr;
+        if (p->isComplete() && p->autoDestroy) {
+            delete p;
+            u->phrases.erase(remove(u->phrases.begin(), u->phrases.end(), p), u->phrases.end());
+            continue;
+        }
+        p->progDisplay();
+        itr++;
+   }
 }
 
 void UIRenderer::removePhrase(Phrase *p) {

--- a/main.cpp
+++ b/main.cpp
@@ -3,18 +3,12 @@
 #include <SDL2/SDL_image.h>
 #include <algorithm>
 #include <vector>
+#include "globals.h"
 #include "Camera.h"
 #include "FpsTimer.h"
 #include "MapParser.h"
-#include "globals.h"
-#include "gui/Phrase.h"
 #include "gui/UIRenderer.h"
-#include "Event.h"
-#include "EventNode.h"
-#include "Timer.h"
-#include "./things/FieldPlayer.h"
-#include "./things/Building.h"
-#include "./components/SimpleMessageI.h"
+#include "events/eventMap.h"
 
 using namespace std;
 
@@ -38,26 +32,17 @@ int main(int argc, char* args[]) {
 
     string fullMapPath(string(BASE_PATH) + "maps/map2.txt");
     parse_map(fullMapPath.c_str());
+    eventMap::initialize();
+
+    gameState = GameState::FieldFree;
+    eventMap::load_events("Burg");
 
     Input in;
     FpsTimer t;
     ProfileData p;
-
-    gameState = GameState::FieldFree;
-
-    /* UI TESTING */
-    Building* ss = Building::find_building("Sailor Shack");
-    CollidableData cd;
-    Ray *ray = new Ray(117,253,173,253);
-    cd.rays.push_back(ray);
-    cd.layer = 0;
-    SimpleMessageI *smi = new SimpleMessageI(ss,"AHHH!!`I'd better run the fuck away from here dude!", cd);
-
-
-    /* END UI TESTING */
     
     while (true){
-    t.startFrame();
+        t.startFrame();
         KeyPresses keysDown = in.getInput();  
         if (keysDown.quit)
             break;

--- a/main.cpp
+++ b/main.cpp
@@ -1,27 +1,29 @@
 #include <SDL2/SDL.h>
 #include <iostream>
 #include <SDL2/SDL_image.h>
+#include <algorithm>
+#include <vector>
 #include "Camera.h"
 #include "FpsTimer.h"
 #include "MapParser.h"
 #include "globals.h"
-#include <vector>
-#include <algorithm>
 #include "gui/Phrase.h"
 #include "gui/UIRenderer.h"
 #include "Event.h"
 #include "EventNode.h"
 #include "Timer.h"
+#include "./things/FieldPlayer.h"
 
 using namespace std;
 
 int test_event_node_callback () {
-        Thing* player = Thing::things["Zinnia"];
         Timer::startOrIgnore("test");
+        DirectionMap dM;
         if(Timer::timeSince("test") < 60) {
-            if (frameCount > 200)
-                player->position.x++;
-            player->position.y++;
+            if (frameCount > 350)
+                dM.right = true;
+            dM.up = true;
+            FieldPlayer::player->walk->move(dM);
             return 0;
         }
         Timer::destroy("test");
@@ -56,8 +58,8 @@ int main(int argc, char* args[]) {
     gameState = GameState::FieldFree;
 
     /* UI TESTING */
-    Phrase *ph = new Phrase(Point(100,100), 220, 80, 1, ScrollType::allButLast, "I think t.");
-    Phrase *ph2 = new Phrase(Point(200,150), 300, 80, 2, ScrollType::allButLast, "Much less text.");
+    Phrase *ph = new Phrase(Point(100,100), 150, 40, 1, ScrollType::allButLast, "What's that??`Is something up and to my right? I'd better go check this shit out.");
+    Phrase *ph2 = new Phrase(Point(200,150), 300, 24, 2, ScrollType::allButLast, "Damn, nothing.");
     EventNode *node, *node2;
     node = new EventNode(&node2, ph, &test_event_node_callback, &test_event_node_callback);
     node2 = new EventNode(NULL, ph2, &test_event_node_callback);
@@ -77,7 +79,7 @@ int main(int argc, char* args[]) {
                 break;
             case (GameState::FieldFree):
             default:
-                if(frameCount == 10)
+                if(frameCount == 300)
                     event->begin();
                 Thing::meatThings(keysDown);
                 break;

--- a/main.cpp
+++ b/main.cpp
@@ -13,22 +13,24 @@
 #include "EventNode.h"
 #include "Timer.h"
 #include "./things/FieldPlayer.h"
+#include "./things/Building.h"
+#include "./components/SimpleMessageI.h"
 
 using namespace std;
 
-int test_event_node_callback () {
-        Timer::startOrIgnore("test");
-        DirectionMap dM;
-        if(Timer::timeSince("test") < 60) {
-            if (frameCount > 350)
-                dM.right = true;
-            dM.up = true;
-            FieldPlayer::player->walk->move(dM);
-            return 0;
-        }
-        Timer::destroy("test");
-        return 1;
-    };
+// int test_event_node_callback () {
+//         Timer::startOrIgnore("test");
+//         DirectionMap dM;
+//         if(Timer::timeSince("test") < 60) {
+//             if (frameCount > 350)
+//                 dM.right = true;
+//             dM.up = true;
+//             FieldPlayer::player->walk->move(dM);
+//             return 0;
+//         }
+//         Timer::destroy("test");
+//         return 1;
+//     };
 
 int main(int argc, char* args[]) {
     SDL_Init(SDL_INIT_VIDEO);
@@ -58,14 +60,24 @@ int main(int argc, char* args[]) {
     gameState = GameState::FieldFree;
 
     /* UI TESTING */
-    Phrase *ph = new Phrase(Point(100,100), 150, 40, 1, ScrollType::allButLast, "What's that??`Is something up and to my right? I'd better go check this shit out.");
-    Phrase *ph2 = new Phrase(Point(200,150), 300, 24, 2, ScrollType::allButLast, "Damn, nothing.");
-    EventNode *node, *node2;
-    node = new EventNode(&node2, ph, &test_event_node_callback, &test_event_node_callback);
-    node2 = new EventNode(NULL, ph2, &test_event_node_callback);
-    Event* event = new Event();
-    event->addNode(node);
-    event->addNode(node2);
+    // Phrase *ph = new Phrase(Point(100,100), 150, 40, 1, ScrollType::continuous, "What's that??`Is something up and to my right? I'd better go check this shit out.");
+    // Phrase *ph2 = new Phrase(Point(200,150), 300, 24, 2, ScrollType::allButLast, "Damn, nothing.");
+    // EventNode *node, *node2;
+    // node = new EventNode(&node2, ph, &test_event_node_callback, &test_event_node_callback);
+    // node2 = new EventNode(NULL, ph2, &test_event_node_callback);
+    // Event* event = new Event();
+    // event->addNode(node);
+    // event->addNode(node2);
+
+    Building* ss = Building::find_building("Sailor Shack");
+
+    CollidableData cd;
+    Ray *ray = new Ray(0,426,117,426);
+    cd.rays.push_back(ray);
+    cd.layer = 0;
+    SimpleMessageI *smi = new SimpleMessageI(ss,"AHHH!!`I'd better run the fuck away from here dude!", cd);
+
+
     /* END UI TESTING */
     
     while (true){
@@ -79,8 +91,8 @@ int main(int argc, char* args[]) {
                 break;
             case (GameState::FieldFree):
             default:
-                if(frameCount == 300)
-                    event->begin();
+                // if(frameCount == 300)
+                //     event->begin();
                 Thing::meatThings(keysDown);
                 break;
         }

--- a/main.cpp
+++ b/main.cpp
@@ -18,20 +18,6 @@
 
 using namespace std;
 
-// int test_event_node_callback () {
-//         Timer::startOrIgnore("test");
-//         DirectionMap dM;
-//         if(Timer::timeSince("test") < 60) {
-//             if (frameCount > 350)
-//                 dM.right = true;
-//             dM.up = true;
-//             FieldPlayer::player->walk->move(dM);
-//             return 0;
-//         }
-//         Timer::destroy("test");
-//         return 1;
-//     };
-
 int main(int argc, char* args[]) {
     SDL_Init(SDL_INIT_VIDEO);
     IMG_Init(IMG_INIT_PNG);
@@ -60,19 +46,9 @@ int main(int argc, char* args[]) {
     gameState = GameState::FieldFree;
 
     /* UI TESTING */
-    // Phrase *ph = new Phrase(Point(100,100), 150, 40, 1, ScrollType::continuous, "What's that??`Is something up and to my right? I'd better go check this shit out.");
-    // Phrase *ph2 = new Phrase(Point(200,150), 300, 24, 2, ScrollType::allButLast, "Damn, nothing.");
-    // EventNode *node, *node2;
-    // node = new EventNode(&node2, ph, &test_event_node_callback, &test_event_node_callback);
-    // node2 = new EventNode(NULL, ph2, &test_event_node_callback);
-    // Event* event = new Event();
-    // event->addNode(node);
-    // event->addNode(node2);
-
     Building* ss = Building::find_building("Sailor Shack");
-
     CollidableData cd;
-    Ray *ray = new Ray(0,426,117,426);
+    Ray *ray = new Ray(117,253,173,253);
     cd.rays.push_back(ray);
     cd.layer = 0;
     SimpleMessageI *smi = new SimpleMessageI(ss,"AHHH!!`I'd better run the fuck away from here dude!", cd);
@@ -91,8 +67,6 @@ int main(int argc, char* args[]) {
                 break;
             case (GameState::FieldFree):
             default:
-                // if(frameCount == 300)
-                //     event->begin();
                 Thing::meatThings(keysDown);
                 break;
         }

--- a/things/Building.cpp
+++ b/things/Building.cpp
@@ -55,3 +55,7 @@ int Building::write_building_datum(ifstream &mapData, BuildingData &newTD) {
 
     return 1;
 }
+
+Building* Building::find_building (string name) {
+    return dynamic_cast<Building*>(Thing::things[name]);
+}

--- a/things/Building.cpp
+++ b/things/Building.cpp
@@ -14,8 +14,8 @@ Building::Building(BuildingData bD) : Thing(bD) {
             height = tmpHeight;
         sprites.push_back(new Sprite(position.x,position.y,name,sd));
     }
-    for (auto bd : bD.obstructionData) {
-        obstructions.push_back(new Obstruction(position.x,position.y,name,bd));
+    for (auto cd : bD.obstructionData) {
+        obstructions.push_back(new Obstruction(this,cd));
     }
 };
 

--- a/things/Building.h
+++ b/things/Building.h
@@ -22,6 +22,7 @@ class Building : public Thing {
         vector<Sprite*> sprites;
         vector<Obstruction*> obstructions;
 
+        static Building *find_building(string name);
         static int write_building_datum(ifstream &mapData, BuildingData &newTD);
 };
 

--- a/things/Building.h
+++ b/things/Building.h
@@ -3,6 +3,7 @@
 
 #include "Thing.h"
 #include "../components/Walk.h"
+#include "../components/Sprite.h"
 #include "../components/Obstruction.h"
 #include <iostream>
 #include <vector>

--- a/things/FieldPlayer.cpp
+++ b/things/FieldPlayer.cpp
@@ -39,7 +39,7 @@ void FieldPlayer::meat(KeyPresses keysDown) {
 
     walk->move(dM);
 
-    if(keysDown.ok) {
+    if(keysDown.ok && gameState == GameState::FieldFree) {
         Ray ray = Ray(position.x + 16, position.y + 32, position.x + 16, position.y - 400);
         Interactable::checkForInteractables(ray, sprite->layer);
         ray = Ray(position.x + 16, position.y + 400, position.x + 16, position.y);

--- a/things/FieldPlayer.cpp
+++ b/things/FieldPlayer.cpp
@@ -4,6 +4,8 @@
 
 using namespace std;
 
+FieldPlayer *FieldPlayer::player = nullptr;
+
 FieldPlayer::FieldPlayer(FieldPlayerData fpD) : Thing(fpD) {
     sprite = new Sprite(position.x,position.y,name,fpD.spriteData);
     sprite->divideSheet(9, 4);
@@ -11,12 +13,13 @@ FieldPlayer::FieldPlayer(FieldPlayerData fpD) : Thing(fpD) {
 
     height = sprite->height;
     width = sprite->width;
-    name = "Zinnia";
-};
+    FieldPlayer::player = this;
+}
 
 FieldPlayer::~FieldPlayer() { 
     delete sprite;
     delete walk;
+    FieldPlayer::player = nullptr;
 };
 
 void FieldPlayer::meat(KeyPresses keysDown) {

--- a/things/FieldPlayer.cpp
+++ b/things/FieldPlayer.cpp
@@ -39,6 +39,17 @@ void FieldPlayer::meat(KeyPresses keysDown) {
 
     walk->move(dM);
 
+    if(keysDown.ok) {
+        Ray ray = Ray(position.x + 16, position.y + 32, position.x + 16, position.y - 400);
+        Interactable::checkForInteractables(ray, sprite->layer);
+        ray = Ray(position.x + 16, position.y + 400, position.x + 16, position.y);
+        Interactable::checkForInteractables(ray, sprite->layer);
+        ray = Ray(position.x + 500, position.y + 400, position.x + 16, position.y);
+        Interactable::checkForInteractables(ray, sprite->layer);
+        ray = Ray(position.x - 500, position.y + 400, position.x + 16, position.y);
+        Interactable::checkForInteractables(ray, sprite->layer);
+    }
+
     /* DEBUG MODE CONTROLS */
     if (keysDown.debug_left && sprite->layer > 0)
         sprite->layer--;

--- a/things/FieldPlayer.cpp
+++ b/things/FieldPlayer.cpp
@@ -7,6 +7,7 @@ using namespace std;
 FieldPlayer *FieldPlayer::player = nullptr;
 
 FieldPlayer::FieldPlayer(FieldPlayerData fpD) : Thing(fpD) {
+    currentDirection = Direction::down;
     sprite = new Sprite(position.x,position.y,name,fpD.spriteData);
     sprite->divideSheet(9, 4);
     walk = new Walk(position.x, position.y, sprite->layer, sprite->sourceRect);
@@ -37,16 +38,29 @@ void FieldPlayer::meat(KeyPresses keysDown) {
     if (keysDown.right)
         dM.right = true;
 
-    walk->move(dM);
+    Direction newDirection = walk->move(dM);
+    currentDirection = newDirection == Direction::none ? currentDirection : newDirection;
 
     if(keysDown.ok && gameState == GameState::FieldFree) {
-        Ray ray = Ray(position.x + 16, position.y + 32, position.x + 16, position.y - 400);
-        Interactable::checkForInteractables(ray, sprite->layer);
-        ray = Ray(position.x + 16, position.y + 400, position.x + 16, position.y);
-        Interactable::checkForInteractables(ray, sprite->layer);
-        ray = Ray(position.x + 500, position.y + 400, position.x + 16, position.y);
-        Interactable::checkForInteractables(ray, sprite->layer);
-        ray = Ray(position.x - 500, position.y + 400, position.x + 16, position.y);
+        int xCenter = position.x + (width / 2);
+        int yBottom = position.y + height;
+        Ray ray;
+        switch (currentDirection) {
+            case (Direction::up):
+                ray = Ray(xCenter, yBottom, xCenter, yBottom - 16);
+                break;
+            case (Direction::down):
+                ray = Ray(xCenter, yBottom, xCenter, yBottom + 16);
+                break;
+            case (Direction::left):
+                ray = Ray(xCenter, yBottom, xCenter - 16, yBottom);
+                break;
+            case (Direction::right):
+                ray = Ray(xCenter, yBottom, xCenter + 16, yBottom);
+                break;
+            default:
+                ray = Ray(xCenter, yBottom, xCenter, yBottom);
+        }
         Interactable::checkForInteractables(ray, sprite->layer);
     }
 

--- a/things/FieldPlayer.cpp
+++ b/things/FieldPlayer.cpp
@@ -47,16 +47,16 @@ void FieldPlayer::meat(KeyPresses keysDown) {
         Ray ray;
         switch (currentDirection) {
             case (Direction::up):
-                ray = Ray(xCenter, yBottom, xCenter, yBottom - 16);
+                ray = Ray(xCenter, yBottom, xCenter, yBottom - 8);
                 break;
             case (Direction::down):
-                ray = Ray(xCenter, yBottom, xCenter, yBottom + 16);
+                ray = Ray(xCenter, yBottom, xCenter, yBottom + 8);
                 break;
             case (Direction::left):
-                ray = Ray(xCenter, yBottom, xCenter - 16, yBottom);
+                ray = Ray(xCenter, yBottom, xCenter - 8, yBottom);
                 break;
             case (Direction::right):
-                ray = Ray(xCenter, yBottom, xCenter + 16, yBottom);
+                ray = Ray(xCenter, yBottom, xCenter + 8, yBottom);
                 break;
             default:
                 ray = Ray(xCenter, yBottom, xCenter, yBottom);

--- a/things/FieldPlayer.h
+++ b/things/FieldPlayer.h
@@ -4,6 +4,7 @@
 #include "Thing.h"
 #include "../Ray.h"
 #include "../components/Walk.h"
+#include "../components/Sprite.h"
 #include "../components/Obstruction.h"
 #include "../components/Interactable.h"
 #include <iostream>

--- a/things/FieldPlayer.h
+++ b/things/FieldPlayer.h
@@ -14,9 +14,9 @@ struct FieldPlayerData : ThingData {
 
 class FieldPlayer : public Thing {
     private:
-        Walk* walk;
         string name;
     public:
+        Walk* walk;
         FieldPlayer(FieldPlayerData fpD);
         ~FieldPlayer();
 
@@ -25,5 +25,8 @@ class FieldPlayer : public Thing {
         void meat(KeyPresses keysDown);
 
         static int write_player_datum(ifstream &mapData, FieldPlayerData &newTD);
+        
+        static FieldPlayer *player;
 };
+
 #endif

--- a/things/FieldPlayer.h
+++ b/things/FieldPlayer.h
@@ -21,6 +21,8 @@ class FieldPlayer : public Thing {
         FieldPlayer(FieldPlayerData fpD);
         ~FieldPlayer();
 
+        Direction currentDirection;
+
         Sprite *sprite;
 
         void meat(KeyPresses keysDown);

--- a/things/FieldPlayer.h
+++ b/things/FieldPlayer.h
@@ -5,6 +5,7 @@
 #include "../Ray.h"
 #include "../components/Walk.h"
 #include "../components/Obstruction.h"
+#include "../components/Interactable.h"
 #include <iostream>
 #include "Camera.h"
 

--- a/things/Thing.h
+++ b/things/Thing.h
@@ -7,7 +7,6 @@
 #include <SDL2/SDL.h>
 #include <fstream>
 #include "../globals.h"
-#include "Sprite.h"
 #include <vector>
 #include "../Ray.h"
 #include <string>


### PR DESCRIPTION
- Adds `eventMap` that stores vectors of functions that populate events, keyed by map name
- Cleans up events
- Adds Interactable class
- Adds checking for interactables by FieldPlayer
- Adds autodestroying phrases
- Adds static `player` pointer and `find_building` function
- Adds newlines to Phrases
- Adds resetting to Phrases
- Adds resetting to Events
- Fixs Phrase scrolling bugs
- Shortens collision ray
- Adds SimpleMessageI interface, to be filled out later
- Changes Camera fade effects to return 1 on completion