### PR TITLE
Add "play" mode to editor

### DIFF
--- a/Camera.h
+++ b/Camera.h
@@ -8,7 +8,6 @@
 #include <string>
 #include "globals.h"
 #include "utils.h"
-#include "./things/Thing.h"
 #include "./things/GhostFocus.h"
 #include "./components/Sprite.h"
 

--- a/MapParser.h
+++ b/MapParser.h
@@ -3,7 +3,6 @@
 #include <string>
 #include <cstring>
 #include <fstream>
-#include "./things/Thing.h"
 #include "./things/FieldPlayer.h"
 #include "./things/RealThing.h"
 #include "editor/MapBuilder.h"

--- a/components/Walk.cpp
+++ b/components/Walk.cpp
@@ -7,8 +7,8 @@ using namespace std;
 
 void Walk::padSide(DirectionMap dM) {
     Ray ray;
-    int xCenter = x + (sprite->d.width / 2);
-    int yBottom = y + sprite->d.height;
+    int xCenter = x;
+    int yBottom = y;
     if (dM.up || dM.down){
         ray = Ray(xCenter, yBottom, xCenter - 5, yBottom);
         if(RealThing::checkAllObstructions(ray, layer)) 
@@ -30,8 +30,8 @@ void Walk::padSide(DirectionMap dM) {
 
 bool Walk::checkCollision(Direction d) {
     Ray ray;
-    int xCenter = x + (sprite->d.width / 2);
-    int yBottom = y + sprite->d.height;
+    int xCenter = x;
+    int yBottom = y;
     switch(d){
         case (Direction::up):
             ray = Ray(xCenter, yBottom, xCenter, yBottom - 6);

--- a/components/Walk.cpp
+++ b/components/Walk.cpp
@@ -7,21 +7,19 @@ using namespace std;
 
 void Walk::padSide(DirectionMap dM) {
     Ray ray;
-    int xCenter = x;
-    int yBottom = y;
     if (dM.up || dM.down){
-        ray = Ray(xCenter, yBottom, xCenter - 5, yBottom);
+        ray = Ray(x, y, x - 5, y);
         if(RealThing::checkAllObstructions(ray, layer)) 
             x += 1;
-        ray = Ray(xCenter, yBottom, xCenter + 5, yBottom);
+        ray = Ray(x, y, x + 5, y);
         if(RealThing::checkAllObstructions(ray, layer)) 
             x -= 1;
     }
     if(dM.left || dM.right) {
-        ray = Ray(xCenter, yBottom, xCenter, yBottom - 5);
+        ray = Ray(x, y, x, y - 5);
         if(RealThing::checkAllObstructions(ray, layer)) 
             y += 1;
-        ray = Ray(xCenter, yBottom, xCenter, yBottom + 5);
+        ray = Ray(x, y, x, y + 5);
         if(RealThing::checkAllObstructions(ray, layer)) 
             y -= 1;
     }
@@ -30,20 +28,18 @@ void Walk::padSide(DirectionMap dM) {
 
 bool Walk::checkCollision(Direction d) {
     Ray ray;
-    int xCenter = x;
-    int yBottom = y;
     switch(d){
         case (Direction::up):
-            ray = Ray(xCenter, yBottom, xCenter, yBottom - 6);
+            ray = Ray(x, y, x, y - 6);
             break;
         case (Direction::down):
-            ray = Ray(xCenter, yBottom, xCenter, yBottom + 6);
+            ray = Ray(x, y, x, y + 6);
             break;
         case (Direction::left):
-            ray = Ray(xCenter, yBottom, xCenter - 6, yBottom);
+            ray = Ray(x, y, x - 6, y);
             break;
         case (Direction::right):
-            ray = Ray(xCenter, yBottom, xCenter + 6, yBottom);
+            ray = Ray(x, y, x + 6, y);
             break;
         default:
             return false;

--- a/components/Walk.h
+++ b/components/Walk.h
@@ -3,9 +3,7 @@
 
 #include <vector>
 #include <../include/SDL2/SDL.h>
-#include "../Ray.h"
-#include "./Sprite.h"
-#include "./things/RealThing.h"
+#include "things/RealThing.h"
 
 class Walk {
     private:

--- a/editor/MapBuilder.cpp
+++ b/editor/MapBuilder.cpp
@@ -35,6 +35,13 @@ void MapBuilder::changeState(EditorState newState) {
             Sprite::removeHighlight();
             state = EditorState::freeMove;
             break;
+        case play:
+            helpText->setText("Play");
+            endTextInput();
+            currentThing = new FieldPlayer(dotThing->position, "test player", "./assets/sheets/SDL_TestSS.png");
+            Camera::panTo(currentThing->name);
+            state = EditorState::play;
+            break;
         case thingMove:
             helpText->setText(prefix + "Thing Move");
             endTextInput();
@@ -48,6 +55,8 @@ void MapBuilder::changeState(EditorState newState) {
             if (currentThing != dotThing) {
                 commandList->setText(commandList->text + "` rename` move` edit sprite` delete");
                 currentThing->removeHighlight();
+            } else {
+                commandList->setText(commandList->text + "` play");
             }
             state = EditorState::commandInput;
             break;
@@ -168,6 +177,15 @@ void MapBuilder::meat(KeyPresses keysDown) {
         }
     }
 
+    if(state == EditorState::play) {
+        if (keysDown.start) {
+            delete currentThing;
+            currentThing = dotThing;
+            changeState(EditorState::freeMove);
+            return;
+        }
+    }
+
     if (state == EditorState::freeMove) {
         if (keysDown.ok) {
             vector<Thing*> collisions = Thing::findThingsByPoint(dotThing->position);
@@ -221,6 +239,12 @@ void MapBuilder::meat(KeyPresses keysDown) {
                     delete currentThing;
                     currentThing = dotThing;
                     changeState(EditorState::freeMove);
+                    return;
+                }
+            }
+            else {
+                if (input == "play") {
+                    changeState(EditorState::play);
                     return;
                 }
             }
@@ -314,5 +338,6 @@ int MapBuilder::addSprite() {
     spriteEditor = new SpriteEditor(currentThing->AddRawSprite(path));
     spriteEditor->sprite->frontAndCenter();
     currentThing->highlightSprite(spriteEditor->sprite);
+
     return 1;
 }

--- a/editor/MapBuilder.h
+++ b/editor/MapBuilder.h
@@ -4,10 +4,7 @@
 #include <string>
 #include "globals.h"
 #include "Camera.h"
-#include "things/Thing.h"
-#include "things/RealThing.h"
 #include "things/FieldPlayer.h"
-#include "components/Sprite.h"
 #include "editor/SpriteEditor.h"
 #include "editor/RayEditor.h"
 #include "gui/Text.h"

--- a/editor/MapBuilder.h
+++ b/editor/MapBuilder.h
@@ -6,6 +6,7 @@
 #include "Camera.h"
 #include "things/Thing.h"
 #include "things/RealThing.h"
+#include "things/FieldPlayer.h"
 #include "components/Sprite.h"
 #include "editor/SpriteEditor.h"
 #include "editor/RayEditor.h"
@@ -21,6 +22,7 @@ using namespace std;
 
 enum EditorState {
     freeMove,
+    play,
     thingMove,
     commandInput,
     renameThing,

--- a/editor/RayEditor.cpp
+++ b/editor/RayEditor.cpp
@@ -14,7 +14,7 @@ RayEditor::RayEditor(RealThing *p) :
     UIRenderer::addLine(parent->position.x, parent->position.y, ray, LineType::editing);
     
     oldFocus = Thing::things[Camera::getFocusName()];
-    focus = new Thing(Point(parent->position.x, parent->position.y));
+    focus = new Thing(Point(parent->position.x, parent->position.y), "ray focus");
     Camera::panTo(focus->name);
 
     text = new Text(Point(LETTER_WIDTH * 2, LETTER_HEIGHT * 4), "");

--- a/editor/RayEditor.h
+++ b/editor/RayEditor.h
@@ -2,11 +2,10 @@
 #define RAY_EDITOR_H
 #include "Input.h"
 #include "Camera.h"
+#include "things/RealThing.h"
 #include "gui/Text.h"
 #include "gui/UIRenderer.h"
 #include "gui/Line.h"
-#include "Ray.h"
-#include "things/RealThing.h"
 
 using namespace std;
 

--- a/editor/SpriteEditor.cpp
+++ b/editor/SpriteEditor.cpp
@@ -8,7 +8,7 @@ SpriteEditor::SpriteEditor(Sprite *s) :
     SpriteData sd;
     
     oldFocus = Thing::things[Camera::getFocusName()];
-    focus = new Thing(Point(sprite->x, sprite->y));
+    focus = new Thing(Point(sprite->x, sprite->y), "sprite focus");
     Camera::panTo(focus->name);
 
     text = new Text(Point(sprite->x, sprite->y), "");

--- a/events/burgEvents.h
+++ b/events/burgEvents.h
@@ -2,8 +2,6 @@
 #define BURG_EVENTS_H
 #include "./eventActions.h"
 #include "things/RealThing.h"
-#include "components/Interactable.h"
-#include "Ray.h"
 
 namespace burgEvents {
     void sailor_shack_test();

--- a/things/FieldPlayer.cpp
+++ b/things/FieldPlayer.cpp
@@ -6,10 +6,25 @@ using namespace std;
 
 FieldPlayer *FieldPlayer::player = nullptr;
 
-FieldPlayer::FieldPlayer(FieldPlayerData fpD) : Thing(fpD) {
+FieldPlayer::FieldPlayer(FieldPlayerData fpD) : RealThing(fpD) {
+    init();
+}
+
+FieldPlayer::FieldPlayer(Point p, string name, string spritePath) : RealThing(p,name) {
+    AddRawSprite(spritePath);
+    init();
+}
+
+FieldPlayer::~FieldPlayer() { 
+    delete walk;
+    FieldPlayer::player = nullptr;
+};
+
+void FieldPlayer::init() {
     currentDirection = Direction::down;
-    sprite = new Sprite(position.x,position.y,name,fpD.spriteData);
+    sprite = sprites[0];
     sprite->divideSheet(9, 4);
+    sprite->frontAndCenter();
     walk = new Walk(position.x, position.y, sprite->d.layer, sprite);
 
     bounds.bottom = sprite->d.height;
@@ -17,11 +32,6 @@ FieldPlayer::FieldPlayer(FieldPlayerData fpD) : Thing(fpD) {
     FieldPlayer::player = this;
 }
 
-FieldPlayer::~FieldPlayer() { 
-    delete sprite;
-    delete walk;
-    FieldPlayer::player = nullptr;
-};
 
 void FieldPlayer::getRay(Ray &r) {
     int xCenter = position.x + (bounds.right / 2);
@@ -79,13 +89,6 @@ void FieldPlayer::meat(KeyPresses keysDown) {
     if (keysDown.debug_down)
         walk->changeSpeed(true);
 
-    if (keysDown.start) {
-        if (Camera::getFocusName() == "Zinnia")
-            Camera::panTo("Sailor Shack");
-        else
-            Camera::panTo("Zinnia");
-    }
-
     if (keysDown.menu1)
         Camera::fadeIn(3);
     if (keysDown.menu2)
@@ -94,9 +97,6 @@ void FieldPlayer::meat(KeyPresses keysDown) {
 };
 
 int FieldPlayer::parse_player_datum(ifstream &mapData, FieldPlayerData &newTD) {
-    Thing::parse_thing_datum(mapData, newTD);
-    SpriteData newSD;
-    Sprite::parse_sprite_datum(mapData,newSD);
-    newTD.spriteData = newSD;
+    RealThing::parse_building_datum(mapData, newTD);
     return 1;
 }

--- a/things/FieldPlayer.h
+++ b/things/FieldPlayer.h
@@ -1,24 +1,22 @@
 #ifndef FIELD_PLAYER_H
 #define FIELD_PLAYER_H
 
-#include "Thing.h"
-#include "../Ray.h"
-#include "../components/Walk.h"
-#include "../components/Sprite.h"
-#include "things/RealThing.h"
 #include <iostream>
+#include "../components/Walk.h"
+#include "things/RealThing.h"
 #include "Camera.h"
 
-struct FieldPlayerData : ThingData {
-    SpriteData spriteData;
+struct FieldPlayerData : RealThingData {
 };
 
-class FieldPlayer : public Thing {
+class FieldPlayer : public RealThing {
     private:
         string name;
+        void init();
     public:
         Walk* walk;
         FieldPlayer(FieldPlayerData fpD);
+        FieldPlayer(Point p, string name, string spritePath);
         ~FieldPlayer();
 
         Direction currentDirection;

--- a/things/GhostFocus.cpp
+++ b/things/GhostFocus.cpp
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-GhostFocus::GhostFocus(Thing *&f, string targetName, bool usePos) : usePosition(usePos), Thing(usePos ? f->position : f->getCenter()), focus(f) {
+GhostFocus::GhostFocus(Thing *&f, string targetName, bool usePos) : usePosition(usePos), Thing(usePos ? f->position : f->getCenter(), "GhostFocus"), focus(f) {
     g = this;
     focus = this;
     target = Thing::things[targetName];

--- a/things/RealThing.cpp
+++ b/things/RealThing.cpp
@@ -1,6 +1,6 @@
-#include "RealThing.h"
 #include <../include/SDL2/SDL_image.h>
 #include <iostream>
+#include "RealThing.h"
 
 using namespace std;
 

--- a/things/RealThing.cpp
+++ b/things/RealThing.cpp
@@ -144,17 +144,17 @@ void RealThing::removeTrigger(string name) {
 };
 
 // Pass in incoming Thing name here to ignore collisions
-int RealThing::checkForCollidables(Ray incoming, int layer, CollidableType collidableType) {
+int RealThing::checkForCollidables(Ray incoming, int incomingLayer, CollidableType collidableType) {
     switch (collidableType) {
         case (CollidableType::obstruction):
             for (auto const& [layer, o] : obstructions){
-            if(o->isColliding(incoming, layer))
+            if(o->isColliding(incoming, incomingLayer))
                 return 1;
             }
             break;
         case (CollidableType::interactable):
             for (auto const& [name, in] : interactables){
-                if(in->isColliding(incoming, layer)) {
+                if(in->isColliding(incoming, incomingLayer)) {
                     if(in->timesTriggered++ == in->maxTriggers || !in->event) {
                         delete in;
                         interactables.erase(name);
@@ -167,7 +167,7 @@ int RealThing::checkForCollidables(Ray incoming, int layer, CollidableType colli
             break;
         case (CollidableType::trigger):
             for (auto const& [name, tr] : triggers){
-                if(tr->isColliding(incoming, layer)) {
+                if(tr->isColliding(incoming, incomingLayer)) {
                     if(tr->timesTriggered++ == tr->maxTriggers || !tr->event) {
                         triggers.erase(name);
                         delete tr;
@@ -275,28 +275,28 @@ void RealThing::hideAllLines() {
     }
 }
 
-int RealThing::checkAllObstructions (Ray incoming, int layer) {
+int RealThing::checkAllObstructions (Ray incoming, int incomingLayer) {
     for (auto const& [n, t] : Thing::things) {
         RealThing* rt = dynamic_cast<RealThing*>(t);
-        if (rt && rt->checkForCollidables(incoming, layer, CollidableType::obstruction))
+        if (rt && rt->checkForCollidables(incoming, incomingLayer, CollidableType::obstruction))
             return 1;
     }
     return 0;
 }
 
-int RealThing::checkAllInteractables (Ray incoming, int layer) {
+int RealThing::checkAllInteractables (Ray incoming, int incomingLayer) {
     for (auto const& [name, t] : Thing::things) {
         RealThing* rt = dynamic_cast<RealThing*>(t);
-        if (rt && rt->checkForCollidables(incoming, layer, CollidableType::interactable))
+        if (rt && rt->checkForCollidables(incoming, incomingLayer, CollidableType::interactable))
             return 1;
     }
     return 0;
 }
 
-int RealThing::checkAllTriggers (Ray incoming, int layer) {
+int RealThing::checkAllTriggers (Ray incoming, int incomingLayer) {
     for (auto const& [name, t] : Thing::things) {
         RealThing* rt = dynamic_cast<RealThing*>(t);
-        if (rt && rt->checkForCollidables(incoming, layer, CollidableType::trigger))
+        if (rt && rt->checkForCollidables(incoming, incomingLayer, CollidableType::trigger))
             return 1;
     }
     return 0;

--- a/things/RealThing.cpp
+++ b/things/RealThing.cpp
@@ -143,6 +143,7 @@ void RealThing::removeTrigger(string name) {
     triggers.erase(name);
 };
 
+// Pass in incoming Thing name here to ignore collisions
 int RealThing::checkForCollidables(Ray incoming, int layer, CollidableType collidableType) {
     switch (collidableType) {
         case (CollidableType::obstruction):
@@ -275,10 +276,10 @@ void RealThing::hideAllLines() {
 }
 
 int RealThing::checkAllObstructions (Ray incoming, int layer) {
-    for (auto const& [name, t] : Thing::things) {
+    for (auto const& [n, t] : Thing::things) {
         RealThing* rt = dynamic_cast<RealThing*>(t);
-        if (rt)
-            return rt->checkForCollidables(incoming, layer, CollidableType::obstruction);
+        if (rt && rt->checkForCollidables(incoming, layer, CollidableType::obstruction))
+            return 1;
     }
     return 0;
 }
@@ -286,8 +287,8 @@ int RealThing::checkAllObstructions (Ray incoming, int layer) {
 int RealThing::checkAllInteractables (Ray incoming, int layer) {
     for (auto const& [name, t] : Thing::things) {
         RealThing* rt = dynamic_cast<RealThing*>(t);
-        if (rt)
-            return rt->checkForCollidables(incoming, layer, CollidableType::interactable);
+        if (rt && rt->checkForCollidables(incoming, layer, CollidableType::interactable))
+            return 1;
     }
     return 0;
 }
@@ -295,8 +296,8 @@ int RealThing::checkAllInteractables (Ray incoming, int layer) {
 int RealThing::checkAllTriggers (Ray incoming, int layer) {
     for (auto const& [name, t] : Thing::things) {
         RealThing* rt = dynamic_cast<RealThing*>(t);
-        if (rt)
-            return rt->checkForCollidables(incoming, layer, CollidableType::trigger);
+        if (rt && rt->checkForCollidables(incoming, layer, CollidableType::trigger))
+            return 1;
     }
     return 0;
 }

--- a/things/RealThing.h
+++ b/things/RealThing.h
@@ -47,7 +47,7 @@ class RealThing : public Thing {
         void removeTrigger(string name);
         void removeObstruction(int layer);
 
-        int checkForCollidables(Ray incoming, int layer, CollidableType collidableType);
+        int checkForCollidables(Ray incoming, int incomingLayer, CollidableType collidableType);
 
         void showObstructionLines(int layer = -1001);
         void showInteractableLines(int layer = -1001, string name = "");
@@ -65,9 +65,9 @@ class RealThing : public Thing {
         static void showAllLines();
         static void hideAllLines();
 
-        static int checkAllObstructions (Ray incoming, int layer);
-        static int checkAllInteractables (Ray incoming, int layer);
-        static int checkAllTriggers (Ray incoming, int layer);
+        static int checkAllObstructions (Ray incoming, int incomingLayer);
+        static int checkAllInteractables (Ray incoming, int incomingLayer);
+        static int checkAllTriggers (Ray incoming, int incomingLayer);
 
         static RealThing *find_building(string name);
         static int parse_building_datum(ifstream &mapData, RealThingData &newTD);

--- a/things/RealThing.h
+++ b/things/RealThing.h
@@ -4,10 +4,10 @@
 #include <iostream>
 #include <vector>
 #include <map>
-#include "Thing.h"
-#include "../components/Sprite.h"
-#include "../components/Obstruction.h"
-#include "../components/Interactable.h"
+#include "things/Thing.h"
+#include "components/Sprite.h"
+#include "components/Obstruction.h"
+#include "components/Interactable.h"
 
 using namespace std;
 

--- a/things/Thing.cpp
+++ b/things/Thing.cpp
@@ -1,7 +1,4 @@
-#include "./things/Thing.h"
-#include <SDL2/SDL.h>
-#include <algorithm>
-#include <SDL2/SDL_image.h>
+#include "things/Thing.h"
 
 using namespace std;
 

--- a/things/Thing.cpp
+++ b/things/Thing.cpp
@@ -12,7 +12,7 @@ void Thing::_save_name_and_save_in_map(string n) {
         name = n + to_string(i);
         i++;
     }
-    Thing::things[name] = this; 
+    Thing::things[name] = this;
 }
 
 Thing::Thing(ThingData td) : 

--- a/things/Thing.h
+++ b/things/Thing.h
@@ -33,6 +33,14 @@ class Thing {
         Thing(Point p);
         virtual ~Thing();
 
+        // Note for Door, etc.:
+        // Have a vector of Thing pointers called dependencies
+        // When we create a Door, we pass in its parent's name, if any, 
+        // and call Thing::things[parentName]->addDependency().
+        // When a Thing is deleted or mannualyControl'd, all of its dependencies follow suit.
+        // We might also store this relationship in a static graph or something if we think
+        // we want to optimize
+        
         virtual void destroy();
         void rename(string newName);
         Point getCenter();

--- a/things/Thing.h
+++ b/things/Thing.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <map>
 #include <vector>
+#include <algorithm>
 #include <SDL2/SDL_image.h>
 #include <SDL2/SDL.h>
 #include "../Input.h"

--- a/things/Thing.h
+++ b/things/Thing.h
@@ -37,10 +37,10 @@ class Thing {
         // Have a vector of Thing pointers called dependencies
         // When we create a Door, we pass in its parent's name, if any, 
         // and call Thing::things[parentName]->addDependency().
-        // When a Thing is deleted or mannualyControl'd, all of its dependencies follow suit.
-        // We might also store this relationship in a static graph or something if we think
-        // we want to optimize
-        
+        // When a Thing is deleted or moved in any way, all of its dependencies must follow suit.
+        // We might also store this relationship in a static graph of pointers,
+        // in addition to a list of Point &references or something if we think we want to optimize
+
         virtual void destroy();
         void rename(string newName);
         Point getCenter();


### PR DESCRIPTION
- Makes FieldPlayer a RealThing
- Centers FieldPlayer
- Adds "play" mode to editor, so we can walk around to test things
- Fixes a bug in collision detection
- Leaves a big note about how to handle dependent things in the future
- Removes some redundant header imports
- Names some functional Things, like temporary Ghost Focuses