### PR TITLE
Cleanup dependency graph

### DIFF
--- a/Camera.h
+++ b/Camera.h
@@ -1,11 +1,8 @@
 #ifndef BACKGROUND_H
 #define BACKGROUND_H
 
-#include <SDL2/SDL_image.h>
-#include <iostream>
 #include <fstream>
 #include <string>
-#include "globals.h"
 #include "./components/Sprite.h"
 
 using namespace std;

--- a/Camera.h
+++ b/Camera.h
@@ -1,13 +1,11 @@
 #ifndef BACKGROUND_H
 #define BACKGROUND_H
 
-#include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
 #include <iostream>
 #include <fstream>
 #include <string>
 #include "globals.h"
-#include "utils.h"
 #include "./components/Sprite.h"
 
 using namespace std;

--- a/FocusTracker.h
+++ b/FocusTracker.h
@@ -35,12 +35,12 @@ struct FocusTracker {
     static void panTo(string thingName, bool snap) {
         if (ftracker == nullptr)
             return;
-        // if (snap) {
+        // if (!snap) {
+        //     // Do some smooth panning shit and maybe lock input or something
         //     c->focus = RealThing::things[thingName];
         //     return;
         // }
         ftracker->setFocus(RealThing::things[thingName]); // Always snap for now
-        // GhostFocus::create(c->focus, thingName, c->focusMode == FocusMode::point);
     }
 
     inline static FocusTracker *ftracker;

--- a/FocusTracker.h
+++ b/FocusTracker.h
@@ -1,6 +1,5 @@
 #ifndef FOCUS_TRACKER_H
 #define FOCUS_TRACKER_H
-#include "Camera.h"
 #include "things/RealThing.h"
 
 enum class FocusMode {

--- a/MapParser.h
+++ b/MapParser.h
@@ -3,7 +3,6 @@
 #include <string>
 #include <cstring>
 #include <fstream>
-#include "./things/FieldPlayer.h"
 #include "editor/MapBuilder.h"
 
 using namespace std;

--- a/MapParser.h
+++ b/MapParser.h
@@ -4,9 +4,7 @@
 #include <cstring>
 #include <fstream>
 #include "./things/FieldPlayer.h"
-#include "./things/RealThing.h"
 #include "editor/MapBuilder.h"
-#include "./FocusTracker.h"
 
 using namespace std;
 

--- a/components/Collidable.h
+++ b/components/Collidable.h
@@ -4,7 +4,6 @@
 #include <string>
 #include <fstream>
 #include "gui/UIRenderer.h"
-#include "gui/Line.h"
 
 using namespace std;
 

--- a/components/Collidable.h
+++ b/components/Collidable.h
@@ -3,7 +3,6 @@
 #include <vector>
 #include <string>
 #include <fstream>
-#include "Ray.h"
 #include "gui/UIRenderer.h"
 #include "gui/Line.h"
 

--- a/components/Sprite.h
+++ b/components/Sprite.h
@@ -4,11 +4,7 @@
 #include <string>
 #include <vector>
 #include <iostream>
-#include <../include/SDL2/SDL.h>
-#include <SDL2/SDL_image.h>
-#include "globals.h"
 #include "Ray.h"
-#include "utils.h"
 #include "resourceDepository.h"
 
 using namespace std;

--- a/components/Walk.cpp
+++ b/components/Walk.cpp
@@ -1,7 +1,5 @@
-#include "globals.h"
 #include "Walk.h"
-#include <SDL2/SDL.h>
-#include <iostream>
+
 
 using namespace std;
 

--- a/components/Walk.h
+++ b/components/Walk.h
@@ -2,7 +2,6 @@
 #define WALK_H
 
 #include <vector>
-#include <../include/SDL2/SDL.h>
 #include "things/RealThing.h"
 
 class Walk {

--- a/editor/CommandLine.h
+++ b/editor/CommandLine.h
@@ -4,8 +4,6 @@
 #include <string>
 #include <deque>
 #include <algorithm>
-#include "globals.h"
-#include "gui/Text.h"
 #include "gui/UIRenderer.h"
 
 using namespace std;

--- a/editor/EventEditor.h
+++ b/editor/EventEditor.h
@@ -1,13 +1,8 @@
 #ifndef EVENT_EDITOR_H
 #define EVENT_EDITOR_H
-#include "Input.h"
-#include "Camera.h"
 #include "util.h"
 #include "things/RealThing.h"
-#include "gui/Text.h"
 #include "gui/UIRenderer.h"
-#include "gui/Line.h"
-#include "gui/MenuDisplay.h"
 #include "events/eventMap.h"
 #include "events/SimpleMessage.h"
 

--- a/editor/EventEditor.h
+++ b/editor/EventEditor.h
@@ -2,7 +2,6 @@
 #define EVENT_EDITOR_H
 #include "util.h"
 #include "things/RealThing.h"
-#include "gui/UIRenderer.h"
 #include "events/eventMap.h"
 #include "events/SimpleMessage.h"
 

--- a/editor/MapBuilder.h
+++ b/editor/MapBuilder.h
@@ -2,15 +2,8 @@
 #define MAP_BUILDER_H
 #include <iostream>
 #include <string>
-#include "globals.h"
 #include "things/FieldPlayer.h"
-#include "editor/SpriteEditor.h"
-#include "editor/RayEditor.h"
-#include "editor/EventEditor.h"
 #include "editor/ThingRouter.h"
-#include "editor/ThingEditor.h"
-#include "gui/Text.h"
-#include "gui/UIRenderer.h"
 
 using namespace std;
 

--- a/editor/MapBuilder.h
+++ b/editor/MapBuilder.h
@@ -2,7 +2,6 @@
 #define MAP_BUILDER_H
 #include <iostream>
 #include <string>
-#include "things/FieldPlayer.h"
 #include "editor/ThingRouter.h"
 
 using namespace std;

--- a/editor/RayEditor.h
+++ b/editor/RayEditor.h
@@ -2,7 +2,6 @@
 #define RAY_EDITOR_H
 #include "FocusTracker.h"
 #include "events/eventMap.h"
-#include "gui/UIRenderer.h"
 
 using namespace std;
 

--- a/editor/RayEditor.h
+++ b/editor/RayEditor.h
@@ -1,12 +1,8 @@
 #ifndef RAY_EDITOR_H
 #define RAY_EDITOR_H
-#include "Input.h"
 #include "FocusTracker.h"
-#include "things/RealThing.h"
 #include "events/eventMap.h"
-#include "gui/Text.h"
 #include "gui/UIRenderer.h"
-#include "gui/Line.h"
 
 using namespace std;
 

--- a/editor/SpriteEditor.h
+++ b/editor/SpriteEditor.h
@@ -4,7 +4,6 @@
 #include "components/Sprite.h"
 #include "FocusTracker.h"
 #include "gui/Text.h"
-#include "gui/UIRenderer.h"
 
 using namespace std;
 

--- a/editor/SpriteEditor.h
+++ b/editor/SpriteEditor.h
@@ -1,9 +1,6 @@
 #ifndef SPRITE_EDITOR_H
 #define SPRITE_EDITOR_H
-#include "Input.h"
-#include "components/Sprite.h"
 #include "FocusTracker.h"
-#include "gui/Text.h"
 
 using namespace std;
 

--- a/editor/ThingEditor.h
+++ b/editor/ThingEditor.h
@@ -2,7 +2,6 @@
 #define THING_EDITOR_H
 #include <iostream>
 #include <string>
-#include "globals.h"
 #include "editor/SpriteEditor.h"
 #include "editor/RayEditor.h"
 #include "editor/EventEditor.h"

--- a/events/Event.h
+++ b/events/Event.h
@@ -7,7 +7,6 @@
 #include <SDL2/SDL_image.h>
 #include "globals.h"
 #include "./EventNode.h"
-#include "Input.h"
 
 using namespace std;
 

--- a/events/Event.h
+++ b/events/Event.h
@@ -3,9 +3,6 @@
 #include <string>
 #include <queue>
 #include <vector>
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_image.h>
-#include "globals.h"
 #include "./EventNode.h"
 
 using namespace std;

--- a/events/EventNode.h
+++ b/events/EventNode.h
@@ -2,12 +2,7 @@
 #define EVENT_NODE_H
 #include <string>
 #include <queue>
-#include <SDL2/SDL.h>
-#include "resourceDepository.h"
-#include "globals.h"
-#include "../gui/Phrase.h"
 #include "../gui/UIRenderer.h"
-#include "Input.h"
 
 using namespace std;
 

--- a/events/burgEvents.h
+++ b/events/burgEvents.h
@@ -3,7 +3,6 @@
 #include "./eventActions.h"
 #include "things/RealThing.h"
 #include "components/Interactable.h"
-#include "Ray.h"
 
 namespace burgEvents {
     Event* testEvent();

--- a/events/burgEvents.h
+++ b/events/burgEvents.h
@@ -1,8 +1,6 @@
 #ifndef BURG_EVENTS_H
 #define BURG_EVENTS_H
 #include "./eventActions.h"
-#include "things/RealThing.h"
-#include "components/Interactable.h"
 
 namespace burgEvents {
     Event* testEvent();

--- a/events/eventActions.h
+++ b/events/eventActions.h
@@ -1,9 +1,6 @@
 #ifndef EVENT_ACTIONS_H
 #define EVENT_ACTIONS_H
-#include "Timer.h"
-#include "Ray.h"
 #include "things/FieldPlayer.h"
-#include "gui/Phrase.h"
 
 namespace testActions {
     int test_event_node_callback ();

--- a/events/eventMap.h
+++ b/events/eventMap.h
@@ -4,8 +4,6 @@
 #include <vector>
 #include <string>
 #include "./burgEvents.h"
-#include "events/Event.h"
-#include "components/Collidable.h"
 
 using namespace std;
 

--- a/gui/Line.h
+++ b/gui/Line.h
@@ -1,7 +1,6 @@
 #ifndef LINE_H
 #define LINE_H
 #include <vector>
-#include "globals.h"
 #include "Camera.h"
 
 using namespace std;

--- a/gui/Line.h
+++ b/gui/Line.h
@@ -1,10 +1,7 @@
 #ifndef LINE_H
 #define LINE_H
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_image.h>
 #include <vector>
 #include "globals.h"
-#include "Ray.h"
 #include "Camera.h"
 
 using namespace std;

--- a/gui/MenuDisplay.h
+++ b/gui/MenuDisplay.h
@@ -5,7 +5,6 @@
 #include <vector>
 #include "Input.h"
 #include "resourceDepository.h"
-#include "Ray.h"
 #include "./Text.h"
 
 using namespace std;

--- a/gui/Phrase.h
+++ b/gui/Phrase.h
@@ -2,10 +2,8 @@
 #define PHRASE_H
 #include <string>
 #include <queue>
-#include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
 #include <cmath>
-#include "globals.h"
 #include "Ray.h"
 #include "Timer.h"
 

--- a/gui/UIRenderer.h
+++ b/gui/UIRenderer.h
@@ -4,8 +4,6 @@
 #include <map>
 #include <vector>
 #include <string>
-#include <SDL2/SDL_image.h>
-#include "globals.h"
 #include "./Phrase.h"
 #include "./Text.h"
 #include "./Line.h"

--- a/gui/UIRenderer.h
+++ b/gui/UIRenderer.h
@@ -1,14 +1,11 @@
 #ifndef UI_MANAGER_H
 #define UI_MANAGER_H
-#include <SDL2/SDL.h>
 #include <map>
 #include <vector>
 #include <string>
 #include "./Phrase.h"
-#include "./Text.h"
 #include "./Line.h"
 #include "./MenuDisplay.h"
-#include "../Camera.h"
 
 using namespace std;
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,9 +1,5 @@
-#include <algorithm>
-#include <vector>
-#include "globals.h"
 #include "FpsTimer.h"
 #include "MapParser.h"
-#include "events/eventMap.h"
 #include "jukebox.h"
 
 using namespace std;

--- a/main.cpp
+++ b/main.cpp
@@ -1,13 +1,8 @@
-#include <SDL2/SDL.h>
-#include <iostream>
-#include <SDL2/SDL_image.h>
 #include <algorithm>
 #include <vector>
 #include "globals.h"
-#include "FocusTracker.h"
 #include "FpsTimer.h"
 #include "MapParser.h"
-#include "gui/UIRenderer.h"
 #include "events/eventMap.h"
 #include "jukebox.h"
 

--- a/resourceDepository.h
+++ b/resourceDepository.h
@@ -2,9 +2,7 @@
 #define RESOURCE_DEPOSITORY_H
 #include <map>
 #include <iostream>
-#include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
-#include <SDL2/SDL_mixer.h>
 #include "globals.h"
 
 using namespace std;

--- a/things/FieldPlayer.cpp
+++ b/things/FieldPlayer.cpp
@@ -1,6 +1,4 @@
 #include "FieldPlayer.h"
-#include <../include/SDL2/SDL_image.h>
-#include <iostream>
 
 using namespace std;
 
@@ -89,10 +87,10 @@ void FieldPlayer::meat(KeyPresses keysDown) {
     // There's no real reason that any of this should live in field player. In face,
     // Field player could only be responsible for literally moving around and
     // not running into things
-    if (keysDown.menu1)
-        Camera::fadeIn(3);
-    if (keysDown.menu2)
-        Camera::fadeOut(3);
+    // if (keysDown.menu1)
+    //     Camera::fadeIn(3);
+    // if (keysDown.menu2)
+    //     Camera::fadeOut(3);
     /* END DEBUG MODE CONTROLS */
 };
 

--- a/things/FieldPlayer.h
+++ b/things/FieldPlayer.h
@@ -2,8 +2,7 @@
 #define FIELD_PLAYER_H
 
 #include <iostream>
-#include "../components/Walk.h"
-#include "things/RealThing.h"
+#include "components/Walk.h"
 
 struct FieldPlayerData : RealThingData {
 };

--- a/things/FieldPlayer.h
+++ b/things/FieldPlayer.h
@@ -4,7 +4,6 @@
 #include <iostream>
 #include "../components/Walk.h"
 #include "things/RealThing.h"
-#include "Camera.h"
 
 struct FieldPlayerData : RealThingData {
 };

--- a/things/RealThing.h
+++ b/things/RealThing.h
@@ -5,20 +5,11 @@
 #include <vector>
 #include <map>
 #include <algorithm>
-#include "components/Sprite.h"
 #include "components/Obstruction.h"
 #include "components/Interactable.h"
 
 // dubiously from Thing.h
 #include <string>
-#include <map>
-#include <vector>
-#include <algorithm>
-#include <SDL2/SDL_image.h>
-#include <SDL2/SDL.h>
-#include "../Input.h"
-#include "../globals.h"
-#include "../Ray.h"
 
 using namespace std;
 


### PR DESCRIPTION
With a sparser dependency graph, we sacrifice being able to see ALL dependencies for each module in order to clearly see the flow of dependencies and pick out code design that should be changed now.

Before:
<img width="1290" alt="Screen Shot 2023-11-04 at 10 14 55 AM" src="https://github.com/tmoliter/bary/assets/3037892/246413e2-c8f0-4ad9-b2f8-580f9d8eeb0d">
After:
<img width="241" alt="Screen Shot 2023-11-04 at 5 58 26 PM" src="https://github.com/tmoliter/bary/assets/3037892/ba4415e6-d994-4de3-b2c9-bdb144c59d08">
