### PR TITLE
Scene portal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ find_package(Lua        REQUIRED)
 set(SOURCES
     barysystem.cpp
     Camera.cpp
+    GameController.cpp
     input.cpp
     inventory.cpp
     jukebox.cpp

--- a/GameController.cpp
+++ b/GameController.cpp
@@ -79,26 +79,26 @@ void GameController::killAllTasks() {
 void GameController::performPendingSceneChange() {
     if (!pendingSceneChange.active)
         return;
-    cout << "[GameController] performing deferred scene change, killing "
-         << activeTasks.size() << " active task(s) from old scene" << endl;
 
-    // 1. The old scene's things are about to be deleted, so kill every task/event
-    //    first or they'll dereference freed things next frame (the MoveST crash).
+    // 1. Kill all active tasks and clear Lua coroutines
     killAllTasks();
 
-    // 2. Carry the moving thing into the new scene.
+    Scene* oldScene = Scene::currentScene;
     Scene* newScene = pendingSceneChange.newScene;
-    newScene->Load(false);
-    RealThing* thing = pendingSceneChange.thing;
-    string baseName = thing->getBaseName();
-    RealThing* carried = new RealThing(*thing);
-    carried->name = baseName;
-    newScene->addExistingThingToScene(carried);
+    RealThing* player = pendingSceneChange.thing;
 
-    // 3. Delete the old scene and enter the new one.
-    newScene->EnterLoaded(carried);
-    carried->position = pendingSceneChange.destination;
-    carried->shiftLayer(pendingSceneChange.newLayer);
+    // 2. Build the new scene's things.
+    newScene->Load(false);
+
+    // 3. Move the real player object to the new scene
+    oldScene->things.erase(player->name);
+    newScene->addExistingThingToScene(player);
+    player->sceneThings = &newScene->things;
+
+    // 4. Delete the old scene and enter the new one (player already moved out).
+    newScene->EnterLoaded(player);
+    player->position = pendingSceneChange.destination;
+    player->shiftLayer(pendingSceneChange.newLayer);
     Camera::c->fadeIn(3);
 
     pendingSceneChange = PendingSceneChange();

--- a/GameController.cpp
+++ b/GameController.cpp
@@ -55,6 +55,53 @@ void GameController::meat(KeyPresses keysDown) {
         return;
     }
     Scene::currentScene->meat(keysDown, controller->activeTasks.size() > 0 && meatEvent(keysDown));
+    performPendingSceneChange();
+}
+
+void GameController::requestSceneChange(Scene* newScene, RealThing* thing, Point destination, int newLayer) {
+    pendingSceneChange.active = true;
+    pendingSceneChange.newScene = newScene;
+    pendingSceneChange.thing = thing;
+    pendingSceneChange.destination = destination;
+    pendingSceneChange.newLayer = newLayer;
+}
+
+void GameController::killAllTasks() {
+    for (auto t : activeTasks)
+        delete t;
+    activeTasks.clear();
+    eventArgKeys.clear();
+    // Drop the Lua-side coroutines too, so nothing resumes against a deleted thing.
+    loadLuaFunc("clearAllEvents");
+    callLuaFunc(0, 0, 0);
+}
+
+void GameController::performPendingSceneChange() {
+    if (!pendingSceneChange.active)
+        return;
+    cout << "[GameController] performing deferred scene change, killing "
+         << activeTasks.size() << " active task(s) from old scene" << endl;
+
+    // 1. The old scene's things are about to be deleted, so kill every task/event
+    //    first or they'll dereference freed things next frame (the MoveST crash).
+    killAllTasks();
+
+    // 2. Carry the moving thing into the new scene.
+    Scene* newScene = pendingSceneChange.newScene;
+    newScene->Load(false);
+    RealThing* thing = pendingSceneChange.thing;
+    string baseName = thing->getBaseName();
+    RealThing* carried = new RealThing(*thing);
+    carried->name = baseName;
+    newScene->addExistingThingToScene(carried);
+
+    // 3. Delete the old scene and enter the new one.
+    newScene->EnterLoaded(carried);
+    carried->position = pendingSceneChange.destination;
+    carried->shiftLayer(pendingSceneChange.newLayer);
+    Camera::c->fadeIn(3);
+
+    pendingSceneChange = PendingSceneChange();
 }
 
 

--- a/GameController.cpp
+++ b/GameController.cpp
@@ -3,8 +3,6 @@
 GameController::GameController(lua_State *L) {
     this->L = L;
     lua_register(L, "_newTask", _newTask);
-    gameManager = new RealThing(RealThingData(Point(0,0), "gameController", ""), mockSceneThings);
-    gameManager->L = L;
     controller = this;
 }
 

--- a/GameController.cpp
+++ b/GameController.cpp
@@ -1,0 +1,83 @@
+#include "GameController.h"
+
+GameController::GameController(lua_State *L) {
+    this->L = L;
+    lua_register(L, "_newTask", _newTask);
+    controller = this;
+}
+
+bool GameController::meatEvent(KeyPresses keysDown) {
+    vector<Task*> tasksToDelete;
+    map<pair<Host*, string>, int> eventsToResume;
+    bool blocking = false;
+    for (int i = activeTasks.size() - 1; i >= 0; i--) {
+        Task* t = activeTasks[i];
+        pair<Host*, string> hostEventName = make_pair(t->host, t->eventName);
+        if (!blocking && t->blocking)
+            blocking = true;
+        if (t->meat(keysDown) < 1) {
+            // task has exhausted subtasks
+            if (!eventsToResume.count(hostEventName))
+                eventsToResume[hostEventName] = eventArgKeys.at(hostEventName);
+            tasksToDelete.push_back(t);
+        } else {
+            if (!eventsToResume.count(hostEventName))
+                eventsToResume[hostEventName] = LUA_NOREF;
+            else
+                eventsToResume.at(hostEventName) = LUA_NOREF;
+        }
+        if (blocking)
+            break;
+    }
+    for (auto t : tasksToDelete) {
+        delete t;
+        activeTasks.erase(remove(activeTasks.begin(), activeTasks.end(), t), activeTasks.end());
+    }
+    for (auto e : eventsToResume) {
+        if (e.second == LUA_NOREF)
+            continue;
+        eventArgKeys.erase(e.first);
+        // All tasks for this event have exhausted subtasks, so we look for more tasks
+        loadLuaFunc("resumeEvent", e.first.first);
+        lua_geti(L, LUA_REGISTRYINDEX, e.second);
+        luaUtils::PushStringToTable(L, "eventName", e.first.second);
+        callLuaFunc(1, 1, 0);
+        luaL_unref(L, LUA_REGISTRYINDEX, e.second);
+    }
+    return blocking;
+}
+
+void GameController::meat(KeyPresses keysDown) {
+    if (Scene::currentScene->sceneState == Scene::SceneState::pauseAll) {
+        // Listen for unpause
+        return;
+    }
+    Scene::currentScene->meat(keysDown, controller->activeTasks.size() > 0 && meatEvent(keysDown));
+}
+
+
+int GameController::_newTask(lua_State *L) {
+    if(!CheckParams(L, {ParamType::pointer, ParamType::str, ParamType::table })) {
+        cout << "_newTask failed!" << endl;
+        throw exception();
+    }
+    RealThing* hostThing = static_cast<RealThing*>(lua_touserdata(L, -1));
+    lua_pop(L, 1);
+
+    string eventName = lua_tostring(L, -1);
+    pair<Host*, string> hostEventName = make_pair(hostThing, eventName);
+    if (!controller->eventArgKeys.count(hostEventName)) {
+        lua_newtable(hostThing->L);
+        controller->eventArgKeys[hostEventName] = luaL_ref(hostThing->L, LUA_REGISTRYINDEX);
+    }
+    Task* newTask = new Task(eventName, hostThing, controller->eventArgKeys[hostEventName]);
+    lua_pop(L, 1);
+
+    lua_xmove(L, hostThing->L, 1);
+
+    newTask->addSubtasks(hostThing->L);
+
+    controller->activeTasks.push_back(newTask);
+    lua_settop(L, 0);
+    return 0;
+}

--- a/GameController.cpp
+++ b/GameController.cpp
@@ -3,6 +3,8 @@
 GameController::GameController(lua_State *L) {
     this->L = L;
     lua_register(L, "_newTask", _newTask);
+    gameManager = new RealThing(RealThingData(Point(0,0), "gameController", ""), mockSceneThings);
+    gameManager->L = L;
     controller = this;
 }
 

--- a/GameController.cpp
+++ b/GameController.cpp
@@ -13,8 +13,6 @@ bool GameController::meatEvent(KeyPresses keysDown) {
     for (int i = activeTasks.size() - 1; i >= 0; i--) {
         Task* t = activeTasks[i];
         pair<Host*, string> hostEventName = make_pair(t->host, t->eventName);
-        if (!blocking && t->blocking)
-            blocking = true;
         if (t->meat(keysDown) < 1) {
             // task has exhausted subtasks
             if (!eventsToResume.count(hostEventName))
@@ -26,8 +24,10 @@ bool GameController::meatEvent(KeyPresses keysDown) {
             else
                 eventsToResume.at(hostEventName) = LUA_NOREF;
         }
-        if (blocking)
+        if (t->blocking) {
+            blocking = true;
             break;
+        }
     }
     for (auto t : tasksToDelete) {
         delete t;

--- a/GameController.h
+++ b/GameController.h
@@ -9,10 +9,14 @@ struct GameController : public Host {
     vector<Task*> activeTasks;
     map<pair<Host*, string> ,int> eventArgKeys;
 
+    map<string, RealThing*> mockSceneThings;
+    RealThing* gameManager;  // Invisible thing used to register events that aren't attached to an actual thing
+
     void meat(KeyPresses keysDown);
     bool meatEvent(KeyPresses keysDown);
 
     static int _newTask(lua_State *L);
+    static int _killAllTasksForThing(lua_State *L);
 
     inline static GameController *controller;
 };

--- a/GameController.h
+++ b/GameController.h
@@ -1,0 +1,20 @@
+#ifndef GAME_CONTROLLER_H
+#define GAME_CONTROLLER_H
+#include "Task.h"
+using namespace luaUtils;
+
+struct GameController : public Host {
+    GameController(lua_State *L);
+
+    vector<Task*> activeTasks;
+    map<pair<Host*, string> ,int> eventArgKeys;
+
+    void meat(KeyPresses keysDown);
+    bool meatEvent(KeyPresses keysDown);
+
+    static int _newTask(lua_State *L);
+
+    inline static GameController *controller;
+};
+
+#endif

--- a/GameController.h
+++ b/GameController.h
@@ -12,6 +12,18 @@ struct GameController : public Host {
     map<string, RealThing*> mockSceneThings;
     RealThing* gameManager;  // Invisible thing used to register events that aren't attached to an actual thing
 
+    struct PendingSceneChange {
+        bool active = false;
+        Scene* newScene = nullptr;
+        RealThing* thing = nullptr;  // thing to carry into the new scene (e.g. the player)
+        Point destination;
+        int newLayer = 0;
+    } pendingSceneChange;
+
+    void requestSceneChange(Scene* newScene, RealThing* thing, Point destination, int newLayer);
+    void performPendingSceneChange();
+    void killAllTasks();
+
     void meat(KeyPresses keysDown);
     bool meatEvent(KeyPresses keysDown);
 

--- a/GameController.h
+++ b/GameController.h
@@ -9,9 +9,6 @@ struct GameController : public Host {
     vector<Task*> activeTasks;
     map<pair<Host*, string> ,int> eventArgKeys;
 
-    map<string, RealThing*> mockSceneThings;
-    RealThing* gameManager;  // Invisible thing used to register events that aren't attached to an actual thing
-
     struct PendingSceneChange {
         bool active = false;
         Scene* newScene = nullptr;

--- a/Scene.cpp
+++ b/Scene.cpp
@@ -2,6 +2,7 @@
 
 Scene::Scene(string sceneName, lua_State *L) : sceneName(sceneName) {
     this->L = L;
+    // We shouldn't be registering in the constructor here, this seems bad
     lua_register(L, "_loadScene", _loadScene);
     lua_register(L, "_createThing", _createThing);
     lua_register(L, "_getThingData", RealThing::_getThingData);
@@ -76,7 +77,6 @@ RealThing* Scene::addThing(RealThingData tD, ThingType type) {
             break;
     }
     newThing->AddToMap(things);
-    newThing->parentScene = this;
     newThing->L = L;
     return newThing;
 }
@@ -84,7 +84,6 @@ RealThing* Scene::addThing(RealThingData tD, ThingType type) {
 RealThing* Scene::addExistingThingToScene(RealThing* existingThing) {
     existingThing->name = getNewThingName(existingThing->name);
     existingThing->AddToMap(things);
-    existingThing->parentScene = this;
     return existingThing;
 }
 
@@ -96,6 +95,7 @@ RealThing* Scene::copyThing(RealThing& oldThing) {
 }
 
 void Scene::destroyThing(RealThing* thing) {
+    // Should this be in thing destructor or is it ok since Scene handles movement/animation?
     for (auto subThing : thing->subThings)
         destroyThing(subThing);
     if (thing->animator != nullptr) {

--- a/Scene.cpp
+++ b/Scene.cpp
@@ -10,7 +10,9 @@ Scene::Scene(string sceneName, lua_State *L) : sceneName(sceneName) {
 Scene::~Scene() {
     destroyAllThings();
     resourceDepository::releaseTexture(bgTextureName);
-    resourceDepository::removeUnreferencedTextures(); // should revisit what this does
+    // resourceDepository::removeUnreferencedTextures(); // should revisit what this does
+    delete Camera::c;
+    delete FocusTracker::ftracker;
 }
 
 void Scene::Load(bool isEditing) {
@@ -26,10 +28,13 @@ void Scene::Load(bool isEditing) {
 }
 
 void Scene::EnterLoaded(RealThing* focus) {
+    if (Scene::currentScene)
+        delete Scene::currentScene;
+
     new Camera();
     Camera::c->bgTextureName = bgTextureName;
-
     Camera::c->init();
+
     new FocusTracker(focus);
     Scene::currentScene = this;
 }
@@ -79,6 +84,7 @@ RealThing* Scene::addThing(RealThingData tD, ThingType type) {
 RealThing* Scene::addExistingThingToScene(RealThing* existingThing) {
     existingThing->name = getNewThingName(existingThing->name);
     existingThing->AddToMap(things);
+    existingThing->parentScene = this;
     return existingThing;
 }
 

--- a/Scene.cpp
+++ b/Scene.cpp
@@ -17,15 +17,11 @@ Scene::~Scene() {
 }
 
 void Scene::Load(bool isEditing) {
-    RealThingData sceneManagerTD = RealThingData();
-    sceneManagerTD.name = "sceneManager";
-    sceneManager = addThing(sceneManagerTD);
     loadLuaFunc("loadScene");
     lua_pushstring(L, sceneName.c_str());
     lua_pushboolean(L, isEditing);
-    lua_pushlightuserdata(L, sceneManager);
     cout << "Loading scene..." << endl;
-    callLuaFunc(3, 0, 0);
+    callLuaFunc(2, 0, 0);
 }
 
 void Scene::EnterLoaded(RealThing* focus) {

--- a/Scene.cpp
+++ b/Scene.cpp
@@ -4,7 +4,6 @@ Scene::Scene(string sceneName, lua_State *L) : sceneName(sceneName) {
     this->L = L;
     lua_register(L, "_loadScene", _loadScene);
     lua_register(L, "_createThing", _createThing);
-    lua_register(L, "_newTask", _newTask);
     lua_register(L, "_getThingData", RealThing::_getThingData);
 }
 
@@ -124,58 +123,8 @@ void Scene::destroyAllThings() {
     }
 }
 
-void Scene::meat(KeyPresses keysDown) {
-    if (sceneState == SceneState::pauseAll) {
-        // Listen for unpause
-        return;
-    }
-    meatThings(keysDown, activeTasks.size() > 0 && meatEvent(keysDown));
-}
 
-
-bool Scene::meatEvent(KeyPresses keysDown) {
-    vector<Task*> tasksToDelete;
-    map<pair<Host*, string>, int> eventsToResume;
-    bool blocking = false;
-    for (int i = activeTasks.size() - 1; i >= 0; i--) {
-        Task* t = activeTasks[i];
-        pair<Host*, string> hostEventName = make_pair(t->host, t->eventName);
-        if (!blocking && t->blocking)
-            blocking = true;
-        if (t->meat(keysDown) < 1) {
-            // task has exhausted subtasks
-            if (!eventsToResume.count(hostEventName))
-                eventsToResume[hostEventName] = eventArgKeys.at(hostEventName);
-            tasksToDelete.push_back(t);
-        } else {
-            if (!eventsToResume.count(hostEventName))
-                eventsToResume[hostEventName] = LUA_NOREF;
-            else
-                eventsToResume.at(hostEventName) = LUA_NOREF;
-        }
-        if (blocking)
-            break;
-    }
-    for (auto t : tasksToDelete) {
-        delete t;
-        activeTasks.erase(remove(activeTasks.begin(), activeTasks.end(), t), activeTasks.end());
-    }
-    for (auto e : eventsToResume) {
-        if (e.second == LUA_NOREF)
-            continue;
-        eventArgKeys.erase(e.first);
-        // All tasks for this event have exhausted subtasks, so we look for more tasks
-        loadLuaFunc("resumeEvent", e.first.first);
-        lua_geti(L, LUA_REGISTRYINDEX, e.second);
-        luaUtils::PushStringToTable(L, "eventName", e.first.second);
-        callLuaFunc(1, 1, 0);
-        luaL_unref(L, LUA_REGISTRYINDEX, e.second);
-    }
-    return blocking;
-}
-
-
-void Scene::meatThings(KeyPresses keysDown, bool blockingEvent) {
+void Scene::meat(KeyPresses keysDown, bool blockingEvent) {
     if (sceneState == SceneState::pauseThings)
         return;
     if (sceneState == SceneState::pausePlayerControl || blockingEvent)
@@ -348,31 +297,3 @@ int Scene::_createThing(lua_State* L) {
     return 1;
 }
 
-int Scene::_newTask(lua_State *L) {
-    if(!CheckParams(L, {ParamType::pointer, ParamType::str, ParamType::table })) {
-        cout << "_newTask failed!" << endl;
-        throw exception();
-    }
-    Host* host = static_cast<Host*>(lua_touserdata(L, -1));
-    lua_pop(L, 1);
-
-    RealThing* hostThing = static_cast<RealThing*>(host);
-    Scene* scene = static_cast<Scene*>(hostThing->parentScene);
-
-    string eventName = lua_tostring(L, -1);
-    pair<Host*, string> hostEventName = make_pair(hostThing, eventName);
-    if (!scene->eventArgKeys.count(hostEventName)) {
-        lua_newtable(host->L);
-        scene->eventArgKeys[hostEventName] = luaL_ref(host->L, LUA_REGISTRYINDEX);
-    }
-    Task* newTask = new Task(eventName, host, scene->eventArgKeys[hostEventName]);
-    lua_pop(L, 1);
-
-    lua_xmove(L, host->L, 1);
-
-    newTask->addSubtasks(host->L);
-
-    scene->activeTasks.push_back(newTask);
-    lua_settop(L, 0);
-    return 0;
-}

--- a/Scene.h
+++ b/Scene.h
@@ -2,7 +2,6 @@
 #define SCENE_H
 #include "FocusTracker.h"
 #include "things/FieldPlayer.h"
-#include "Task.h"
 
 using namespace luaUtils;
 
@@ -15,9 +14,6 @@ struct Scene : public Host {
         pauseThings,
         pauseAll,
     } sceneState;
-
-    vector<Task*> activeTasks;
-    map<pair<Host*, string> ,int> eventArgKeys;
 
     string sceneName;
     string bgTextureName;
@@ -33,9 +29,7 @@ struct Scene : public Host {
     void Load(bool isEditing);
     void EnterLoaded(RealThing* focus);
 
-    void meat(KeyPresses keysDown);
-    bool meatEvent(KeyPresses keysDown);
-    void meatThings(KeyPresses keysDown, bool blockingEvent);
+    void meat(KeyPresses keysDown, bool blockingEvent);
 
     RealThing* addThing(RealThingData tD, ThingType type = ThingType::thing);
     RealThing* addExistingThingToScene(RealThing* existingThing);
@@ -63,7 +57,6 @@ struct Scene : public Host {
 
     static int _loadScene(lua_State* L);
     static int _createThing(lua_State* L);
-    static int _newTask(lua_State *L);
 
     private:
         string getNewThingName(string name);

--- a/Scene.h
+++ b/Scene.h
@@ -24,8 +24,6 @@ struct Scene : public Host {
     Scene(string sceneName, lua_State *L);
     ~Scene();
 
-    RealThing* sceneManager; // Invisible thing used to register events that aren't attached to an actual thing
-
     void Load(bool isEditing);
     void EnterLoaded(RealThing* focus);
 

--- a/Scene.h
+++ b/Scene.h
@@ -24,7 +24,7 @@ struct Scene : public Host {
     Scene(string sceneName, lua_State *L);
     ~Scene();
 
-    RealThing* sceneManager;
+    RealThing* sceneManager; // Invisible thing used to register events that aren't attached to an actual thing
 
     void Load(bool isEditing);
     void EnterLoaded(RealThing* focus);

--- a/Task.cpp
+++ b/Task.cpp
@@ -197,6 +197,11 @@ void PortalST::init() {
     else
         thing = hostThing;
 
+    string newSceneName = "";
+    if(luaUtils::GetLuaStringFromTable(L,"newScene",newSceneName)) {
+        newScene = new Scene(newSceneName, thing->L);
+    }
+
     luaUtils::GetLuaIntFromTable(L, "newLayer", newLayer);
     Point relativeMove;
     if (!luaUtils::GetLuaIntFromTable(L, "relativeX", relativeMove.x) ||
@@ -234,6 +239,14 @@ PortalST::~PortalST() {
 
 bool PortalST::meat(KeyPresses keysDown) {
     if (Camera::c->fadeStatus == FxStatus::applied) {
+        if (newScene) {
+            newScene->Load(false);
+            string thingBaseName = thing->getBaseName();
+            thing = new RealThing(*thing);
+            thing->name = thingBaseName;
+            newScene->addExistingThingToScene(thing);
+            newScene->EnterLoaded(thing);
+        }
         thing->position = destination;
         thing->shiftLayer(newLayer);
         Camera::c->fadeIn(3);

--- a/Task.cpp
+++ b/Task.cpp
@@ -162,7 +162,7 @@ void MoveST::init() {
     Point offset;
     RealThing* hostThing = static_cast<RealThing*>(host);
     if (luaUtils::GetLuaStringFromTable(L, "thingName", thingName)) {
-        movingThing = hostThing->sceneThings.at(thingName);
+        movingThing = hostThing->sceneThings->at(thingName);
     } else {
         movingThing = hostThing;
     }
@@ -194,7 +194,7 @@ void PortalST::init() {
     if (Host::GetLuaHostFromTable(L, "thing", incomingThing))
         thing = static_cast<RealThing*>(incomingThing);
     else if (luaUtils::GetLuaStringFromTable(L, "thingName", thingName))
-        thing = hostThing->sceneThings.at(thingName);
+        thing = hostThing->sceneThings->at(thingName);
     else
         thing = hostThing;
 
@@ -202,7 +202,6 @@ void PortalST::init() {
     if(luaUtils::GetLuaStringFromTable(L,"newScene",newSceneName)) {
         newScene = new Scene(newSceneName, thing->L);
     }
-    cout << "[PortalST::init] read newScene='" << newSceneName << "' -> newScene ptr=" << newScene << endl;
 
     luaUtils::GetLuaIntFromTable(L, "newLayer", newLayer);
     Point relativeMove;
@@ -224,7 +223,7 @@ void PortalST::init() {
     }
 
     Camera::fadeOut(3);
-    for (auto const& [id, t] : thing->sceneThings) {
+    for (auto const& [id, t] : *thing->sceneThings) {
         if (!t->move)
             continue;
         t->move->disables += 1;
@@ -232,7 +231,7 @@ void PortalST::init() {
 }
 
 PortalST::~PortalST() {
-    for (auto const& [id, t] : thing->sceneThings) {
+    for (auto const& [id, t] : *thing->sceneThings) {
         if (!t->move)
             continue;
         t->move->disables -= 1;
@@ -241,8 +240,6 @@ PortalST::~PortalST() {
 
 bool PortalST::meat(KeyPresses keysDown) {
     if (Camera::c->fadeStatus == FxStatus::applied) {
-        cout << "[PortalST::meat] fade applied, newScene=" << newScene
-             << (newScene ? " -> requesting deferred scene change" : " -> in-scene teleport only") << endl;
         if (newScene) {
             // Don't swap inline: we're mid-iteration over activeTasks and the old
             // scene's things are still live. Hand off to GameController, which runs
@@ -381,7 +378,7 @@ void Task::pauseMoves(lua_State* L) {
     RealThing* hostThing = static_cast<RealThing*>(host);
     int disable = luaUtils::CheckLuaTableForBool(L, "unpause") ? -1 : 1;
     if (luaUtils::CheckLuaTableForBool(L, "all")) {
-        for (auto const& [id, thing] : hostThing->sceneThings) {
+        for (auto const& [id, thing] : *hostThing->sceneThings) {
             if (!thing->move)
                 continue;
             thing->move->disables += disable;
@@ -405,9 +402,9 @@ void Task::pauseMoves(lua_State* L) {
         lua_pop(L,1);
     }
     for (auto thingName : thingNames) {
-        if (!hostThing->sceneThings.count(thingName))
+        if (!hostThing->sceneThings->count(thingName))
             continue;
-        RealThing* thing = hostThing->sceneThings.at(thingName);
+        RealThing* thing = hostThing->sceneThings->at(thingName);
         if (!thing->move)
             continue;
         thing->move->disables += disable;

--- a/Task.cpp
+++ b/Task.cpp
@@ -241,10 +241,6 @@ PortalST::~PortalST() {
 bool PortalST::meat(KeyPresses keysDown) {
     if (Camera::c->fadeStatus == FxStatus::applied) {
         if (newScene) {
-            // Don't swap inline: we're mid-iteration over activeTasks and the old
-            // scene's things are still live. Hand off to GameController, which runs
-            // the swap at a safe boundary after the task loop, killing old-scene
-            // tasks first. This subtask is done once the request is queued.
             GameController::controller->requestSceneChange(newScene, thing, destination, newLayer);
             return 1;
         }
@@ -273,16 +269,6 @@ int Task::meat(KeyPresses keysDown) {
         subtasks.erase(remove(subtasks.begin(), subtasks.end(), s), subtasks.end());
     }
     return subtasks.size();
-}
-
-void Task::killEvent() {
-    for (auto s : subtasks) {
-        delete s;
-        subtasks.erase(remove(subtasks.begin(), subtasks.end(), s), subtasks.end());
-    }
-    host->loadLuaFunc("killEvent");
-    lua_pushstring(host->L, eventName.c_str());
-    host->callLuaFunc(1, 0, 0);
 }
 
 void Task::addSubtasks(lua_State* L) {

--- a/Task.cpp
+++ b/Task.cpp
@@ -274,6 +274,16 @@ int Task::meat(KeyPresses keysDown) {
     return subtasks.size();
 }
 
+void Task::killEvent() {
+    for (auto s : subtasks) {
+        delete s;
+        subtasks.erase(remove(subtasks.begin(), subtasks.end(), s), subtasks.end());
+    }
+    host->loadLuaFunc("killEvent");
+    lua_pushstring(host->L, eventName.c_str());
+    host->callLuaFunc(1, 0, 0);
+}
+
 void Task::addSubtasks(lua_State* L) {
     if (!lua_istable(L, -1))
         luaUtils::ThrowLua(L, "top of stack is not list of subTasks!");
@@ -399,3 +409,16 @@ void Task::pauseMoves(lua_State* L) {
         thing->move->disables += disable;
     }
 }
+
+// NOTES
+/*
+- things should call lua to kill tasks when they die. Lua should both remove the 
+  entry from activeEvents and calll a new GameController::_killTasks registered function
+
+- Portal should call lua to change scenes in a new function of some sort. This function
+  can call back to C++ into a GameController registered function that handles scene changing
+  without relying on a hostThing.
+
+- Need to serialize (some) thing data to lua when scene ends so we can save in gameState
+  for next time we enter the scene and ultimately for saving game data to disk
+*/

--- a/Task.cpp
+++ b/Task.cpp
@@ -161,7 +161,7 @@ void MoveST::init() {
     Point offset;
     RealThing* hostThing = static_cast<RealThing*>(host);
     if (luaUtils::GetLuaStringFromTable(L, "thingName", thingName)) {
-        movingThing = hostThing->things.at(thingName);
+        movingThing = hostThing->sceneThings.at(thingName);
     } else {
         movingThing = hostThing;
     }
@@ -193,7 +193,7 @@ void PortalST::init() {
     if (Host::GetLuaHostFromTable(L, "thing", incomingThing))
         thing = static_cast<RealThing*>(incomingThing);
     else if (luaUtils::GetLuaStringFromTable(L, "thingName", thingName))
-        thing = hostThing->things.at(thingName);
+        thing = hostThing->sceneThings.at(thingName);
     else
         thing = hostThing;
 
@@ -222,7 +222,7 @@ void PortalST::init() {
     }
 
     Camera::fadeOut(3);
-    for (auto const& [id, t] : thing->things) {
+    for (auto const& [id, t] : thing->sceneThings) {
         if (!t->move)
             continue;
         t->move->disables += 1;
@@ -230,7 +230,7 @@ void PortalST::init() {
 }
 
 PortalST::~PortalST() {
-    for (auto const& [id, t] : thing->things) {
+    for (auto const& [id, t] : thing->sceneThings) {
         if (!t->move)
             continue;
         t->move->disables -= 1;
@@ -377,7 +377,7 @@ void Task::pauseMoves(lua_State* L) {
     RealThing* hostThing = static_cast<RealThing*>(host);
     int disable = luaUtils::CheckLuaTableForBool(L, "unpause") ? -1 : 1;
     if (luaUtils::CheckLuaTableForBool(L, "all")) {
-        for (auto const& [id, thing] : hostThing->things) {
+        for (auto const& [id, thing] : hostThing->sceneThings) {
             if (!thing->move)
                 continue;
             thing->move->disables += disable;
@@ -401,24 +401,11 @@ void Task::pauseMoves(lua_State* L) {
         lua_pop(L,1);
     }
     for (auto thingName : thingNames) {
-        if (!hostThing->things.count(thingName))
+        if (!hostThing->sceneThings.count(thingName))
             continue;
-        RealThing* thing = hostThing->things.at(thingName);
+        RealThing* thing = hostThing->sceneThings.at(thingName);
         if (!thing->move)
             continue;
         thing->move->disables += disable;
     }
 }
-
-// NOTES
-/*
-- things should call lua to kill tasks when they die. Lua should both remove the 
-  entry from activeEvents and calll a new GameController::_killTasks registered function
-
-- Portal should call lua to change scenes in a new function of some sort. This function
-  can call back to C++ into a GameController registered function that handles scene changing
-  without relying on a hostThing.
-
-- Need to serialize (some) thing data to lua when scene ends so we can save in gameState
-  for next time we enter the scene and ultimately for saving game data to disk
-*/

--- a/Task.cpp
+++ b/Task.cpp
@@ -1,4 +1,5 @@
 #include "Task.h"
+#include "GameController.h"
 
 Subtask::Subtask(lua_State* L,  Host* host) : L(L), timer(nullptr), host(host) {
     if (!lua_istable(L, -1)) {
@@ -201,6 +202,7 @@ void PortalST::init() {
     if(luaUtils::GetLuaStringFromTable(L,"newScene",newSceneName)) {
         newScene = new Scene(newSceneName, thing->L);
     }
+    cout << "[PortalST::init] read newScene='" << newSceneName << "' -> newScene ptr=" << newScene << endl;
 
     luaUtils::GetLuaIntFromTable(L, "newLayer", newLayer);
     Point relativeMove;
@@ -239,13 +241,15 @@ PortalST::~PortalST() {
 
 bool PortalST::meat(KeyPresses keysDown) {
     if (Camera::c->fadeStatus == FxStatus::applied) {
+        cout << "[PortalST::meat] fade applied, newScene=" << newScene
+             << (newScene ? " -> requesting deferred scene change" : " -> in-scene teleport only") << endl;
         if (newScene) {
-            newScene->Load(false);
-            string thingBaseName = thing->getBaseName();
-            thing = new RealThing(*thing);
-            thing->name = thingBaseName;
-            newScene->addExistingThingToScene(thing);
-            newScene->EnterLoaded(thing);
+            // Don't swap inline: we're mid-iteration over activeTasks and the old
+            // scene's things are still live. Hand off to GameController, which runs
+            // the swap at a safe boundary after the task loop, killing old-scene
+            // tasks first. This subtask is done once the request is queued.
+            GameController::controller->requestSceneChange(newScene, thing, destination, newLayer);
+            return 1;
         }
         thing->position = destination;
         thing->shiftLayer(newLayer);

--- a/Task.cpp
+++ b/Task.cpp
@@ -159,7 +159,7 @@ void MoveST::init() {
     string thingName;
     Point destination;
     Point offset;
-    RealThing* hostThing = static_cast<RealThing*>(host); // (assume-host)
+    RealThing* hostThing = static_cast<RealThing*>(host);
     if (luaUtils::GetLuaStringFromTable(L, "thingName", thingName)) {
         movingThing = hostThing->things.at(thingName);
     } else {
@@ -189,7 +189,7 @@ bool MoveST::meat(KeyPresses keysDown) {
 void PortalST::init() {
     Host* incomingThing;
     string thingName = "";
-    RealThing* hostThing = static_cast<RealThing*>(host); // (assume-host)
+    RealThing* hostThing = static_cast<RealThing*>(host);
     if (Host::GetLuaHostFromTable(L, "thing", incomingThing))
         thing = static_cast<RealThing*>(incomingThing);
     else if (luaUtils::GetLuaStringFromTable(L, "thingName", thingName))

--- a/Task.h
+++ b/Task.h
@@ -1,6 +1,6 @@
 #ifndef TASK_H
 #define TASK_H
-#include "things/RealThing.h"
+#include "Scene.h"
 #include <set>
 
 enum class SubTaskType {
@@ -62,6 +62,7 @@ struct PortalST : public Subtask {
     RealThing* thing = nullptr;
     Point destination;
     int newLayer;
+    Scene* newScene;
 };
 
 struct Task {

--- a/Task.h
+++ b/Task.h
@@ -61,8 +61,8 @@ struct PortalST : public Subtask {
     virtual bool meat(KeyPresses keysDown);
     RealThing* thing = nullptr;
     Point destination;
-    int newLayer;
-    Scene* newScene;
+    int newLayer = 0;
+    Scene* newScene = nullptr;
 };
 
 // A task is a group of "subtasks", which can be fired from an event in lua.

--- a/Task.h
+++ b/Task.h
@@ -81,6 +81,8 @@ struct Task {
     bool blocking = false; // blocking stops any older events from being executed. If we just want to pause movement, that can be done with the `pauseMoves` subtask
     int meat(KeyPresses keysDown);
 
+    void killEvent(); // removes all subtasks in C++ and removes task from Lua activeEvents table
+
     void addSubtasks(lua_State* L);
 
     // Instant subtasks

--- a/Task.h
+++ b/Task.h
@@ -65,12 +65,19 @@ struct PortalST : public Subtask {
     Scene* newScene;
 };
 
+// A task is a group of "subtasks", which can be fired from an event in lua.
+// An event is a lua function that gets called as a coroutine and can fire off
+// Tasks in between yield statements
 struct Task {
     Task(string eventName, Host* host, int argKey) : eventName(eventName), host(host), argKey(argKey) {};
     string eventName;
     std::vector<Subtask*> subtasks;
     Host* host;
+
+    // I didn't document this at all when I wrote it. Looking back, I'm
+    // retty sure this stores a table of args for continuity throughout events
     int argKey = LUA_NOREF;
+
     bool blocking = false; // blocking stops any older events from being executed. If we just want to pause movement, that can be done with the `pauseMoves` subtask
     int meat(KeyPresses keysDown);
 

--- a/Task.h
+++ b/Task.h
@@ -81,8 +81,6 @@ struct Task {
     bool blocking = false; // blocking stops any older events from being executed. If we just want to pause movement, that can be done with the `pauseMoves` subtask
     int meat(KeyPresses keysDown);
 
-    void killEvent(); // removes all subtasks in C++ and removes task from Lua activeEvents table
-
     void addSubtasks(lua_State* L);
 
     // Instant subtasks

--- a/components/Animator.cpp
+++ b/components/Animator.cpp
@@ -5,6 +5,10 @@ Animator::Animator(Sprite* sprite) :
     type(AnimationType::movement) {
 };
 
+Animator::Animator(Animator& oldAnimator) : type(oldAnimator.type) {
+    sprite = new Sprite(*oldAnimator.sprite);
+}
+
 void Animator::splitSheet(int columns, int rows) {
     sprite->divideSheet(columns, rows);
     sprite->frontAndCenter();

--- a/components/Animator.h
+++ b/components/Animator.h
@@ -8,6 +8,7 @@ enum class AnimationType {
 
 struct Animator {
     Animator(Sprite* sprite);
+    Animator(Animator&);
 
     Sprite* sprite;
     AnimationType type;

--- a/components/Move.cpp
+++ b/components/Move.cpp
@@ -2,6 +2,20 @@
 
 using namespace std;
 
+Move::Move(Move& oldMove) :
+    type(oldMove.type), 
+    currentDirection(oldMove.currentDirection), 
+    leader(oldMove.leader),
+    speed(oldMove.speed), 
+    layer(oldMove.layer),
+    tolerance(oldMove.tolerance),
+    destination(oldMove.destination) {
+    if (oldMove.leader) {
+        leader = new Point(*oldMove.leader);
+    }
+}
+
+
 void Move::moveFromInput(KeyPresses keysDown) {
     if (disables)
         return;

--- a/components/Move.h
+++ b/components/Move.h
@@ -20,6 +20,8 @@ struct Move {
         destination(Point(-1000,-1000))
     {};
 
+    Move(Move&);
+
     MoveType type;
     Direction currentDirection;
     Point* leader;

--- a/components/Sprite.cpp
+++ b/components/Sprite.cpp
@@ -26,7 +26,7 @@ Sprite::Sprite(Sprite &sprite) :
     sheetHeight(sprite.sheetHeight) {
     id = currentID++;
     sprites[id] = this;
-    // should we increment texture reference here?
+    // should we increment texture reference here??? And manage our shit better in general?
 }
 
 Sprite::Sprite(Sprite &sprite, Point &pos, string &tN) :

--- a/components/Sprite.cpp
+++ b/components/Sprite.cpp
@@ -26,6 +26,7 @@ Sprite::Sprite(Sprite &sprite) :
     sheetHeight(sprite.sheetHeight) {
     id = currentID++;
     sprites[id] = this;
+    // should we increment texture reference here?
 }
 
 Sprite::Sprite(Sprite &sprite, Point &pos, string &tN) :

--- a/editor/ThingRouter.cpp
+++ b/editor/ThingRouter.cpp
@@ -117,7 +117,7 @@ int ThingRouter::chooseEditAction(KeyPresses keysDown) {
             return 1 ;
         }
         realThing->PushThingDataOnStack();
-        lua_pushstring(L, static_cast<Scene*>(realThing->parentScene)->sceneName.c_str());
+        lua_pushstring(L, static_cast<Scene*>(Scene::currentScene)->sceneName.c_str());
         if (!luaUtils::CheckLua(L, lua_pcall(L, 2, 0, 0))) {
             cout << "FAILED TO PRINT!" << endl;
         }

--- a/games/barycenter/saves/bullshit.lua
+++ b/games/barycenter/saves/bullshit.lua
@@ -7,6 +7,20 @@ return {
         scale = 2
     },
     scenes = {
+        testSceneTwo = {
+            things = { 
+                {
+                    name = "otherZinnia",
+                    x = 1300,
+                    y = 500
+                },
+                {
+                    name = "sailorShack",
+                    x = 621,
+                    y = 510,
+                }
+            } 
+        },
         burg = {
             things = { 
                 {

--- a/games/barycenter/saves/bullshit.lua
+++ b/games/barycenter/saves/bullshit.lua
@@ -33,7 +33,7 @@ return {
                     x = 621,
                     y = 510,
                 }
-            } 
+            }
         }
     },
     inventories = {

--- a/games/barycenter/scenes/testSceneTwo/map.lua
+++ b/games/barycenter/scenes/testSceneTwo/map.lua
@@ -1,0 +1,34 @@
+return {
+    things = { 
+        {
+            name = "otherZinnia",
+            x = 1000,
+            y = 500
+        },
+        {
+            name = "otherZinnia",
+            x = 694,
+            y = 500
+        },
+        {
+            name = "otherZinnia",
+            x = 800,
+            y = 500
+        },
+        {
+            name = "sailorShack",
+            x = 723,
+            y = 1037,
+        },
+        {
+            name = "sailorShack",
+            x = 1500,
+            y = 1037,
+        },
+        {
+            name = "genrlStore",
+            x = 621,
+            y = 510,
+        }
+    } 
+}

--- a/games/barycenter/scenes/testSceneTwo/setup.lua
+++ b/games/barycenter/scenes/testSceneTwo/setup.lua
@@ -1,8 +1,8 @@
 local Resources = require('scripts.resourceobject')
 local resources = Resources.new({
-    background = "burg",
+    background = "tg",
     ownTextures = {
-        burg = "backgrounds/Burg",
+        tg = "backgrounds/tg",
         genrl = "sheets/Burg/genrl",
         sailorshack = "sheets/Burg/SailorShack",
         zinnia = "sheets/SDL_TestSS"
@@ -314,7 +314,6 @@ local thingDefs = {
                             relativeX = -25,
                             relativeY = -131,
                             newLayer = 2,
-                            newScene = "testSceneTwo"
                         },
                         closeAfter = true,
                         -- locked = true

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
 #include "barysystem.h"
 #include "FpsTimer.h"
 #include "editor/MapBuilder.h"
+#include "GameController.h"
 
 using namespace std;
 
@@ -22,11 +23,14 @@ int main(int argc, char* args[]) {
 
     vector<string> saveNames;
     barysystem::startup(saveNames);
+
     lua_getglobal(L, "loadBaseResources");
     if(!luaUtils::CheckLua(L, lua_pcall(L, 0, 1, 0)))
         throw exception();
     resourceDepository::loadTexturesFromTable(L);
     lua_settop(L, 0);
+
+    new GameController(L);
 
     // jukebox::playSong("Boss Battle", true);
 
@@ -85,7 +89,7 @@ int main(int argc, char* args[]) {
             switch(gameState) {
                 case (GameState::FieldFree):
                 default:
-                    Scene::currentScene->meat(keysDown);
+                    GameController::controller->meat(keysDown);
                     t.timeElapsed(&p.d);
 
                     FocusTracker::ftracker->setCameraFocalPoint();

--- a/main.cpp
+++ b/main.cpp
@@ -121,8 +121,6 @@ int main(int argc, char* args[]) {
     SDL_DestroyRenderer(renderer);
     SDL_DestroyWindow(window);
 
-    delete Camera::c;
-
     Mix_CloseAudio();
     lua_close(L);
     IMG_Quit();

--- a/main.cpp
+++ b/main.cpp
@@ -15,6 +15,9 @@ int main(int argc, char* args[]) {
     if (!CheckLua(L, luaL_dofile(L, "scripts/load.lua")))
         throw exception();
 
+    // Register all our lua functions here
+    // Including a new Task::_killTasks static method
+
     gameState = GameState::FieldFree;
 
     Input in;

--- a/main.cpp
+++ b/main.cpp
@@ -35,12 +35,6 @@ int main(int argc, char* args[]) {
 
     new GameController(L);
 
-    lua_getglobal(L, "loadBaseResources");
-    lua_pushlightuserdata(L, GameController::controller->gameManager);
-    if(!luaUtils::CheckLua(L, lua_pcall(L, 1, 0, 0)))
-        throw exception();
-    lua_settop(L, 0);
-
     // jukebox::playSong("Boss Battle", true);
 
     MenuDisplay* loadMenu = nullptr;

--- a/main.cpp
+++ b/main.cpp
@@ -35,6 +35,12 @@ int main(int argc, char* args[]) {
 
     new GameController(L);
 
+    lua_getglobal(L, "loadBaseResources");
+    lua_pushlightuserdata(L, GameController::controller->gameManager);
+    if(!luaUtils::CheckLua(L, lua_pcall(L, 1, 0, 0)))
+        throw exception();
+    lua_settop(L, 0);
+
     // jukebox::playSong("Boss Battle", true);
 
     MenuDisplay* loadMenu = nullptr;

--- a/resourceDepository.cpp
+++ b/resourceDepository.cpp
@@ -17,14 +17,6 @@ Sfx::Sfx(string n, string path) : name(n) {
     }
     sound = Mix_LoadWAV(path.c_str());
 }
-void resourceDepository::loadTexture(string name, string simplePath) {
-    cout << simplePath << endl;
-    if(!textures.count(name))
-        textures[name] = make_pair(0,new Texture(name, simplePath));
-    else
-        cout << "texture " << name << " is already loaded, skipping\n";
-}
-
 Texture* resourceDepository::getTexture(string name) {
     if(!textures.count(name)) {
         cout << "Cannot get texture " << name << " that is not loaded!\n";
@@ -69,6 +61,14 @@ void resourceDepository::loadTexturesFromTable(lua_State *L) {
         lua_pop(L,1);
     }
     lua_pop(L,1);
+}
+
+void resourceDepository::loadTexture(string name, string simplePath) {
+    cout << name << " : " << simplePath << endl;
+    if(!textures.count(name))
+        textures[name] = make_pair(0,new Texture(name, simplePath));
+    else
+        cout << "texture " << name << " is already loaded, skipping\n";
 }
 
 void resourceDepository::loadScene(lua_State *L) {

--- a/scripts/copy.lua
+++ b/scripts/copy.lua
@@ -6,7 +6,6 @@ function deepcopy(obj)
 end
 
 function deepmerge(target, source)
-    print(tostring(source))
     for k,v in pairs(source) do
         if type(target[k]) == 'table' and type(source[k]) == 'table' then
             deepmerge(target[k], source[k])

--- a/scripts/event.lua
+++ b/scripts/event.lua
@@ -1,5 +1,6 @@
 local activeEvents = {}
 local eventDefinitions = {}
+gameManager = nil
 
 -- maybe make a bulk beginEvents function here
 
@@ -28,7 +29,7 @@ local function beginEvent(hostThing, args)
     end
 
 
-    activeEvent["args"] = { gameState = gameState }
+    activeEvent["args"] = { gameState = gameState, activeEvents = activeEvents }
     for k,v in pairs(eventDefinition) do activeEvent["args"][k] = v end
     for k,v in pairs(args) do activeEvent["args"][k] = v end
 
@@ -83,13 +84,14 @@ local function populate(thingDefs, sceneEvents)
     for _,thing in pairs(thingDefs) do
         populateEvents(thing)
     end
-    eventDefinitions.sceneManager = sceneEvents
+    eventDefinitions.gameManager = sceneEvents
 end
 
 return {
     beginEvent = beginEvent,
     resumeEvent = resumeEvent,
-    populate = populate
+    populate = populate,
+    gameManager = gameManager
 }
 
 --[[

--- a/scripts/event.lua
+++ b/scripts/event.lua
@@ -69,6 +69,10 @@ local function resumeEvent(hostThing, args)
     return 1
 end
 
+local function clearAllEvents(hostThing)
+    activeEvents = {}
+end
+
 local function populateEvents(thing)
     -- we might do additional stuff with components here
     if eventDefinitions[thing["name"]] == nil then eventDefinitions[thing["name"]] = thing["events"] end
@@ -91,6 +95,7 @@ return {
     beginEvent = beginEvent,
     resumeEvent = resumeEvent,
     populate = populate,
+    clearAllEvents = clearAllEvents,
     gameManager = gameManager
 }
 

--- a/scripts/event.lua
+++ b/scripts/event.lua
@@ -1,6 +1,5 @@
 local activeEvents = {}
 local eventDefinitions = {}
-gameManager = nil
 
 -- maybe make a bulk beginEvents function here
 
@@ -29,7 +28,7 @@ local function beginEvent(hostThing, args)
     end
 
 
-    activeEvent["args"] = { gameState = gameState, activeEvents = activeEvents }
+    activeEvent["args"] = { gameState = gameState }
     for k,v in pairs(eventDefinition) do activeEvent["args"][k] = v end
     for k,v in pairs(args) do activeEvent["args"][k] = v end
 
@@ -95,8 +94,7 @@ return {
     beginEvent = beginEvent,
     resumeEvent = resumeEvent,
     populate = populate,
-    clearAllEvents = clearAllEvents,
-    gameManager = gameManager
+    clearAllEvents = clearAllEvents
 }
 
 --[[

--- a/scripts/event.lua
+++ b/scripts/event.lua
@@ -11,16 +11,17 @@ local function beginEvent(hostThing, args)
         eventDefinition = eventDefinitions[args["thingName"]][args.eventName]
     end
 
-    -- Event has never been invoked
+    -- No events have been invoked for this thing?
     if activeEvents[hostThing] == nil then
         activeEvents[hostThing] = {}
     end
+    -- Event has never been invoked
     if activeEvents[hostThing][args.eventName] == nil then
         activeEvents[hostThing][args.eventName] = { timesInvoked = 0 }
     end
 
     local activeEvent = activeEvents[hostThing][args.eventName]
-    
+
     -- Event is already in progress
     if activeEvent["coroutine"] ~= nil then
         return

--- a/scripts/load.lua
+++ b/scripts/load.lua
@@ -43,8 +43,10 @@ function loadScene(host, sceneName, isEditing, newSceneManager)
         mapTable = require(GAME_PATH .. '.scenes.' .. sceneName .. '.map')
     else
         mapTable = gameState["scenes"][sceneName]
-        playerSpawn = thingDefs[gameState["spawn"]["name"]]
-        for k,v in pairs(gameState["spawn"]) do playerSpawn[k] = v end
+        if gameState["spawn"] then
+            playerSpawn = thingDefs[gameState["spawn"]["name"]]
+            for k,v in pairs(gameState["spawn"]) do playerSpawn[k] = v end
+        end
     end
 
     eventModule.populate(thingDefs, sceneEvents)
@@ -60,7 +62,12 @@ function loadScene(host, sceneName, isEditing, newSceneManager)
     if playerSpawn ~= nil then
         table.insert(spawnThings, playerSpawn)
     end
+    gameState["spawn"] = nil
 
+    print("ay " .. resources.background)
+    print(resources:getTextures().tg)
+    print(resources:getTextures().burg)
+    print("k")
     _loadScene(resources.background, spawnThings, { textures = resources:getTextures() }, host)
 end
 

--- a/scripts/load.lua
+++ b/scripts/load.lua
@@ -6,6 +6,7 @@ itemDefinitions = require(GAME_PATH .. ".definitions.itemDefinitions")
 local eventModule = require("scripts.event")
 beginEvent = eventModule.beginEvent
 resumeEvent = eventModule.resumeEvent
+clearAllEvents = eventModule.clearAllEvents
 local baseResources = require('base.resources')
 
 function loadBaseResources()

--- a/scripts/load.lua
+++ b/scripts/load.lua
@@ -15,10 +15,6 @@ function loadBaseResources()
     return baseResources:getTextures()
 end
 
-function initializeGameManager(gameManager)
-    eventModule.gameManager = gameManager
-end
-
 function loadGame(saveFile)
     local saveData = require(GAME_PATH .. ".saves." .. saveFile)
 

--- a/scripts/load.lua
+++ b/scripts/load.lua
@@ -64,10 +64,6 @@ function loadScene(host, sceneName, isEditing, newSceneManager)
     end
     gameState["spawn"] = nil
 
-    print("ay " .. resources.background)
-    print(resources:getTextures().tg)
-    print(resources:getTextures().burg)
-    print("k")
     _loadScene(resources.background, spawnThings, { textures = resources:getTextures() }, host)
 end
 

--- a/scripts/load.lua
+++ b/scripts/load.lua
@@ -3,7 +3,6 @@ require("config.settings")
 gameState = require('state.gameState')
 standardEvents = require('scripts.standardEvents')
 itemDefinitions = require(GAME_PATH .. ".definitions.itemDefinitions")
-sceneManager = nil
 local eventModule = require("scripts.event")
 beginEvent = eventModule.beginEvent
 resumeEvent = eventModule.resumeEvent
@@ -13,6 +12,10 @@ function loadBaseResources()
     local Resources = require('scripts.resourceobject')
     local baseResources = Resources.new({ baseTextures = baseResources.UI })
     return baseResources:getTextures()
+end
+
+function initializeGameManager(gameManager)
+    eventModule.gameManager = gameManager
 end
 
 function loadGame(saveFile)
@@ -30,8 +33,7 @@ function loadGame(saveFile)
     return saveData.spawn
 end
 
-function loadScene(host, sceneName, isEditing, newSceneManager)
-    sceneManager = newSceneManager
+function loadScene(host, sceneName, isEditing)
     local setup = require(GAME_PATH .. '.scenes.' .. sceneName .. '.setup')
     local resources, thingDefs, sceneEvents = table.unpack(setup)
 

--- a/scripts/standardEvents.lua
+++ b/scripts/standardEvents.lua
@@ -1,3 +1,4 @@
+require("scripts.copy")
 local function sequentialTasks(hostThing, args)
     local tasks = args["tasks"]
     if args["pauseAllMoves"] then
@@ -167,6 +168,11 @@ local function menu(hostThing, args)
     }, args.eventName, hostThing)
     return
 end
+
+local function changeScene (hostThing, args)
+    
+end
+
 
 return {
     sequentialTasks = sequentialTasks,

--- a/scripts/standardEvents.lua
+++ b/scripts/standardEvents.lua
@@ -169,11 +169,6 @@ local function menu(hostThing, args)
     return
 end
 
-local function changeScene (hostThing, args)
-    
-end
-
-
 return {
     sequentialTasks = sequentialTasks,
     randomAutoMove = randomAutoMove,

--- a/things/FieldPlayer.cpp
+++ b/things/FieldPlayer.cpp
@@ -4,7 +4,7 @@ using namespace std;
 
 FieldPlayer *FieldPlayer::player = nullptr;
 
-FieldPlayer::FieldPlayer(RealThingData tD, map<string, RealThing*>& things) : RealThing(tD, things) {
+FieldPlayer::FieldPlayer(RealThingData tD, map<string, RealThing*>& sceneThings) : RealThing(tD, sceneThings) {
     type = ThingType::fieldPlayer;
     AddAnimator();
     AddMove(MoveType::controlled);
@@ -28,7 +28,7 @@ void FieldPlayer::meat(KeyPresses keysDown) {
         loadLuaFunc("beginEvent");
         lua_newtable(L);
         luaUtils::PushStringToTable(L, "eventName", "inventoryMenu");
-        luaUtils::PushStringToTable(L, "thingName", "sceneManager");
+        luaUtils::PushStringToTable(L, "thingName", "gameManager");
         luaUtils::PushStringToTable(L, "catalyst", "input");
         luaUtils::PushStringToTable(L, "inventoryName", name);
         callLuaFunc(1,0,0);
@@ -51,7 +51,7 @@ void FieldPlayer::meat(KeyPresses keysDown) {
 int FieldPlayer::castRayForInteractables () {
     if (move == nullptr)
         return 0;
-    for (auto const& [name, t] : things) {
+    for (auto const& [name, t] : sceneThings) {
         if (t == this)
             continue;
         for (auto r : getRaysFromOriginAndDirection(position, move->currentDirection))
@@ -64,7 +64,7 @@ int FieldPlayer::castRayForInteractables () {
 int FieldPlayer::castRayForTriggers () {
     if (move == nullptr)
         return 0;
-    for (auto const& [name, t] : things) {
+    for (auto const& [name, t] : sceneThings) {
         if (t == this)
             continue;
         for (auto r : getRaysFromOriginAndDirection(position, move->currentDirection))

--- a/things/FieldPlayer.cpp
+++ b/things/FieldPlayer.cpp
@@ -51,7 +51,7 @@ void FieldPlayer::meat(KeyPresses keysDown) {
 int FieldPlayer::castRayForInteractables () {
     if (move == nullptr)
         return 0;
-    for (auto const& [name, t] : sceneThings) {
+    for (auto const& [name, t] : *sceneThings) {
         if (t == this)
             continue;
         for (auto r : getRaysFromOriginAndDirection(position, move->currentDirection))
@@ -64,7 +64,7 @@ int FieldPlayer::castRayForInteractables () {
 int FieldPlayer::castRayForTriggers () {
     if (move == nullptr)
         return 0;
-    for (auto const& [name, t] : sceneThings) {
+    for (auto const& [name, t] : *sceneThings) {
         if (t == this)
             continue;
         for (auto r : getRaysFromOriginAndDirection(position, move->currentDirection))

--- a/things/FieldPlayer.h
+++ b/things/FieldPlayer.h
@@ -6,6 +6,7 @@
 
 struct FieldPlayer : public RealThing {
     FieldPlayer(RealThingData tD, map<string, RealThing*>& things);
+    FieldPlayer(FieldPlayer&);
     ~FieldPlayer();
 
     void meat(KeyPresses keysDown);

--- a/things/FieldPlayer.h
+++ b/things/FieldPlayer.h
@@ -5,7 +5,7 @@
 #include "RealThing.h"
 
 struct FieldPlayer : public RealThing {
-    FieldPlayer(RealThingData tD, map<string, RealThing*>& things);
+    FieldPlayer(RealThingData tD, map<string, RealThing*>& sceneThings);
     FieldPlayer(FieldPlayer&);
     ~FieldPlayer();
 

--- a/things/RealThing.cpp
+++ b/things/RealThing.cpp
@@ -23,6 +23,12 @@ RealThing::RealThing(RealThing &oldThing) : position(oldThing.position), bounds(
     for (auto const& [oldTrName, oldTr] : oldThing.triggers)
         triggers[oldTrName] = new Trigger(*oldTr, position, name);
     origin = position;
+    if (oldThing.animator) {
+        animator = new Animator(*oldThing.animator);
+    }
+    if (oldThing.move) {
+        move = new Move(*oldThing.move);
+    }
     parentScene = oldThing.parentScene;
 }
 

--- a/things/RealThing.cpp
+++ b/things/RealThing.cpp
@@ -5,7 +5,7 @@ RealThing::RealThing(RealThingData tD, map<string, RealThing*>& tL) :
     position(tD.x, tD.y),
     animator(nullptr),
     move(nullptr),
-    things(tL) {
+    sceneThings(tL) {
     origin = position;
     for (auto sd : tD.spriteDataVector)
         AddSprite(sd);
@@ -13,7 +13,7 @@ RealThing::RealThing(RealThingData tD, map<string, RealThing*>& tL) :
         addObstruction(cd.rays, cd.layer);
 }
 
-RealThing::RealThing(RealThing &oldThing) : position(oldThing.position), bounds(oldThing.bounds), things(oldThing.things) {
+RealThing::RealThing(RealThing &oldThing) : position(oldThing.position), bounds(oldThing.bounds), sceneThings(oldThing.sceneThings) {
     for (auto oldS : oldThing.sprites)
         sprites.push_back(new Sprite(*oldS, position, name));
     for (auto const& [layer, oldO] : oldThing.obstructions)
@@ -217,7 +217,7 @@ void RealThing::addComponentsFromTable() {
             AddMove(MoveType::follow);
             luaUtils::GetLuaIntFromTable(L, "tolerance", move->tolerance);
             luaUtils::GetLuaStringFromTable(L, "targetName", targetName);
-            move->leader = &things.at(targetName)->position;
+            move->leader = &sceneThings.at(targetName)->position;
         }
         if (currentComponent == "moveAnimate") {
             AddAnimator();
@@ -670,7 +670,7 @@ int RealThing::_getThingData(lua_State* L) {
     RealThing* thing = static_cast<RealThing*>(lua_touserdata(L, -1));
     lua_pop(L, 1);
     if (lua_isstring(L, -1)) {
-        thing = thing->things.at(lua_tostring(L, -1));
+        thing = thing->sceneThings.at(lua_tostring(L, -1));
         lua_pop(L,1);
     }
 

--- a/things/RealThing.cpp
+++ b/things/RealThing.cpp
@@ -29,7 +29,6 @@ RealThing::RealThing(RealThing &oldThing) : position(oldThing.position), bounds(
     if (oldThing.move) {
         move = new Move(*oldThing.move);
     }
-    parentScene = oldThing.parentScene;
 }
 
 RealThing::~RealThing() {

--- a/things/RealThing.cpp
+++ b/things/RealThing.cpp
@@ -5,7 +5,7 @@ RealThing::RealThing(RealThingData tD, map<string, RealThing*>& tL) :
     position(tD.x, tD.y),
     animator(nullptr),
     move(nullptr),
-    sceneThings(tL) {
+    sceneThings(&tL) {
     origin = position;
     for (auto sd : tD.spriteDataVector)
         AddSprite(sd);
@@ -217,7 +217,7 @@ void RealThing::addComponentsFromTable() {
             AddMove(MoveType::follow);
             luaUtils::GetLuaIntFromTable(L, "tolerance", move->tolerance);
             luaUtils::GetLuaStringFromTable(L, "targetName", targetName);
-            move->leader = &sceneThings.at(targetName)->position;
+            move->leader = &sceneThings->at(targetName)->position;
         }
         if (currentComponent == "moveAnimate") {
             AddAnimator();
@@ -670,7 +670,7 @@ int RealThing::_getThingData(lua_State* L) {
     RealThing* thing = static_cast<RealThing*>(lua_touserdata(L, -1));
     lua_pop(L, 1);
     if (lua_isstring(L, -1)) {
-        thing = thing->sceneThings.at(lua_tostring(L, -1));
+        thing = thing->sceneThings->at(lua_tostring(L, -1));
         lua_pop(L,1);
     }
 

--- a/things/RealThing.h
+++ b/things/RealThing.h
@@ -34,7 +34,6 @@ struct RealThing : public Host {
     bool isSub = false;
 
     map<string, RealThing*>& things;
-    Host* parentScene;
 
     Point position;
     Point origin;

--- a/things/RealThing.h
+++ b/things/RealThing.h
@@ -33,7 +33,7 @@ struct RealThing : public Host {
     ThingType type;
     bool isSub = false;
 
-    map<string, RealThing*>& sceneThings;
+    map<string, RealThing*>* sceneThings; 
 
     Point position;
     Point origin;

--- a/things/RealThing.h
+++ b/things/RealThing.h
@@ -33,7 +33,7 @@ struct RealThing : public Host {
     ThingType type;
     bool isSub = false;
 
-    map<string, RealThing*>& things;
+    map<string, RealThing*>& sceneThings;
 
     Point position;
     Point origin;


### PR DESCRIPTION
- add new test scene
- drop `sceneManager` C++ code and just key global events under `gameManager` in Lua
- add some copy constructors — originally for a scene change procedure that didn't manifest, but hey they're still good for the editor
- converted `sceneThings` from refs to pointers
- add GameController class
- hoist event/task handling from Scene to GameController
- add optional `newScene` attribute to Portal subtask, read from it to initiate a scene change
- add data structure to store a deferred request to change scenes
- add post-meat code to kill all active tasks and shut down the scene, load new scene, and move player to it