### PR TITLE
Comment Cleanup Part 1

### DIFF
--- a/.lldbinit
+++ b/.lldbinit
@@ -1,0 +1,5 @@
+# Keep stopping on crashes so you get a full, un-unwound stack trace, but
+# pass the signal through to our handler in main.cpp on `continue` so the
+# audio device gets released instead of staying claimed until a restart.
+process handle SIGABRT --stop true --pass true --notify true
+process handle SIGSEGV --stop true --pass true --notify true

--- a/barysystem.cpp
+++ b/barysystem.cpp
@@ -17,21 +17,19 @@ void barysystem::startup(vector<string>& saveNames) {
     IMG_Init(IMG_INIT_PNG);
     SDL_SetHint(SDL_HINT_RENDER_VSYNC, "1");
 
-    // audio stuff is commented out because it fucks with the laptop sound after debugging
+    if( Mix_OpenAudio(44100, AUDIO_S16SYS, 2, 512) < 0 )
+    {
+        fprintf(stderr, "Unable to open audio: %s\n", SDL_GetError());
+        exit(-1);
+    }
 
-    // if( Mix_OpenAudio(44100, AUDIO_S16SYS, 2, 512) < 0 )
-    // {
-    //     fprintf(stderr, "Unable to open audio: %s\n", SDL_GetError());
-    //     exit(-1);
-    // }
+    if( Mix_AllocateChannels(4) < 0 )
+    {
+        fprintf(stderr, "Unable to open audio: %s\n", SDL_GetError());
+        exit(-1);
+    }
 
-    // if( Mix_AllocateChannels(4) < 0 )
-    // {
-    //     fprintf(stderr, "Unable to open audio: %s\n", SDL_GetError());
-    //     exit(-1);
-    // }
-
-    SDL_Window* window = SDL_CreateWindow(
+    window = SDL_CreateWindow(
         "Bary",
         SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
         settings.FULLSCREEN_MODE ? 0 : settings.SCREEN_WIDTH, settings.FULLSCREEN_MODE ? 0 :settings.SCREEN_HEIGHT,

--- a/barysystem.cpp
+++ b/barysystem.cpp
@@ -36,7 +36,7 @@ void barysystem::startup(vector<string>& saveNames) {
         settings.FULLSCREEN_MODE ? SDL_WINDOW_FULLSCREEN_DESKTOP : SDL_WINDOW_SHOWN
     );
 
-    // Play with third arguemnt?
+    // Play with third argument?
     renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
     if (settings.FULLSCREEN_MODE) {
         SDL_RenderSetLogicalSize(renderer, settings.SCREEN_WIDTH, settings.SCREEN_HEIGHT);

--- a/components/Sprite.cpp
+++ b/components/Sprite.cpp
@@ -21,12 +21,11 @@ Sprite::Sprite(Sprite &sprite) :
     d(sprite.d),
     alpha(sprite.alpha),
     active(sprite.active),
-    texture(sprite.texture),
     sheetWidth(sprite.sheetWidth),
     sheetHeight(sprite.sheetHeight) {
     id = currentID++;
     sprites[id] = this;
-    // should we increment texture reference here??? And manage our shit better in general?
+    texture = resourceDepository::getTexture(d.textureName)->texture;
 }
 
 Sprite::Sprite(Sprite &sprite, Point &pos, string &tN) :
@@ -34,11 +33,11 @@ Sprite::Sprite(Sprite &sprite, Point &pos, string &tN) :
     d(sprite.d),
     alpha(sprite.alpha),
     active(sprite.active),
-    texture(sprite.texture),
     sheetWidth(sprite.sheetWidth),
     sheetHeight(sprite.sheetHeight) {
     id = currentID++;
     sprites[id] = this;
+    texture = resourceDepository::getTexture(d.textureName)->texture;
 }
 
 Sprite::~Sprite() {

--- a/gui/Line.h
+++ b/gui/Line.h
@@ -5,13 +5,14 @@
 
 using namespace std;
 
+// In order of painting
 enum class LineType {
+    obstruction,
     interactable,
     trigger,
-    obstruction,
-    editing,
+    line,
     highlight,
-    line
+    editing
 };
 
 struct Line {

--- a/gui/MenuDisplay.h
+++ b/gui/MenuDisplay.h
@@ -37,13 +37,11 @@ struct MenuDisplay {
     Point position;
     Text flavorText;
 
-    // SDL_Rect bubbleSourceRect = { 0, 0, 640, 480 };
     SDL_Rect rightArrow = { settings.LETTER_WIDTH * 0, settings.LETTER_HEIGHT * 4, settings.LETTER_WIDTH, settings.LETTER_HEIGHT };
     SDL_Rect upArrow = { settings.LETTER_WIDTH * 2, settings.LETTER_HEIGHT * 4, settings.LETTER_WIDTH, settings.LETTER_HEIGHT };
     SDL_Rect downArrow = { settings.LETTER_WIDTH * 3, settings.LETTER_HEIGHT * 4, settings.LETTER_WIDTH, settings.LETTER_HEIGHT };
 
 
-    // void addFlavor(vector<string> newFlavor);
     void buildPages();
     void createLists();
     void clearLists();

--- a/gui/UIRenderer.cpp
+++ b/gui/UIRenderer.cpp
@@ -52,25 +52,13 @@ void UIRenderer::renderMenuDisplays() {
 }
 
 bool _compareType (Line* a, Line* b) {
-    // TODO Order the enum and use static int cast and compare
-    if (a->type == LineType::highlight)
-        return false;
-    if (b->type == LineType::highlight)
-        return true;
-    if (a->type == LineType::editing)
-        return true;
-    if (b->type == LineType::editing)
-        return false;
-    if (a->type == LineType::obstruction)
-        return true;
-    return false;
+    return static_cast<int>(a->type) < static_cast<int>(b->type);
 }
 void UIRenderer::renderLines() {
-    // 12-31-23 commenting this out because of a bug in the editor, should investigate later
-    // sort(u->lines.begin(), u->lines.end(), _compareType);
-    // for (auto l : u->lines) {
-    //     l->render();
-    // }
+    stable_sort(u->lines.begin(), u->lines.end(), _compareType);
+    for (auto l : u->lines) {
+        l->render();
+    }
 }
 
 void UIRenderer::render() {

--- a/main.cpp
+++ b/main.cpp
@@ -2,10 +2,21 @@
 #include "FpsTimer.h"
 #include "editor/MapBuilder.h"
 #include "GameController.h"
+#include <csignal>
 
 using namespace std;
 
+void releaseAudioOnFatalSignal(int sig) {
+    Mix_CloseAudio();
+    SDL_Quit();
+    signal(sig, SIG_DFL);
+    raise(sig);
+}
+
 int main(int argc, char* args[]) {
+    signal(SIGABRT, releaseAudioOnFatalSignal);
+    signal(SIGSEGV, releaseAudioOnFatalSignal);
+
     // Change to the resource directory immediately so relative asset paths
     // work whether the binary is run directly or launched as a .app bundle.
     cd(BASE_PATH);
@@ -35,7 +46,7 @@ int main(int argc, char* args[]) {
 
     new GameController(L);
 
-    // jukebox::playSong("Boss Battle", true);
+    jukebox::playSong("Boss Battle", true);
 
     MenuDisplay* loadMenu = nullptr;
     vector<Option> startOptions;

--- a/things/RealThing.h
+++ b/things/RealThing.h
@@ -116,7 +116,17 @@ struct RealThing : public Host {
 
     virtual RealThing* copyInPlace();
 
-    static int _getThingData(lua_State* L); // currently unused
+    // Meant to be called in event functions so that we can dynamic location into tasks, e.g.:
+    // local thingData = _getThingData(hostThing) // returns location of hostThing
+    // local otherThingData = _getThingData(hostThing, "thingName") // returns location of thing named "thingName"
+    //  _newTask({
+    //         {
+    //             type = "move",
+    //             destinationX = thingData["x"],
+    //             destinationY = otherThingData["y"]
+    //         },
+    //. })
+    static int _getThingData(lua_State* L);
 };
 
 #endif


### PR DESCRIPTION
- Add signal handler to shut down SDL resources on uncaught exception
- Paint rays by enum order
- Mop up unused members and improve comment for genuinely useful unused function
- Increment texture count when copying Sprite