### PR TITLE
Use smart pointers for resource management

### DIFF
--- a/Camera.cpp
+++ b/Camera.cpp
@@ -26,8 +26,8 @@ Point Camera::getSourceRectCoords() {
 }
 
 void Camera::init() {
-    bgTexture = resourceDepository::getTexture(bgTextureName)->texture;
-    SDL_QueryTexture(bgTexture, NULL, NULL, &bgWidth, &bgHeight);
+    bgTexture = resourceDepository::getTexture(bgTextureName);
+    SDL_QueryTexture(bgTexture->texture, NULL, NULL, &bgWidth, &bgHeight);
     sourceRect = { 0 , 0, scaledScreenWidth, scaledScreenHeight };
     renderRect = { 0 , 0, settings.SCREEN_WIDTH, settings.SCREEN_HEIGHT };
     fadeStart = warpStart = frameCount;
@@ -40,7 +40,7 @@ void Camera::renderBackground() {
     if (!initialized)
         return;
     setPosition();
-    SDL_RenderCopy(renderer, bgTexture, &sourceRect, &renderRect);
+    SDL_RenderCopy(renderer, bgTexture->texture, &sourceRect, &renderRect);
 }
 
 void Camera::renderAfterEffects() {

--- a/Camera.h
+++ b/Camera.h
@@ -17,7 +17,7 @@ enum class FxStatus {
 class Camera {
     private:
         SDL_Rect renderRect, sourceRect;
-        SDL_Texture* bgTexture;
+        shared_ptr<Texture> bgTexture;
         int fadeStart, warpStart;
     public:
         Point focalPoint;

--- a/Scene.cpp
+++ b/Scene.cpp
@@ -10,8 +10,6 @@ Scene::Scene(string sceneName, lua_State *L) : sceneName(sceneName) {
 
 Scene::~Scene() {
     destroyAllThings();
-    resourceDepository::releaseTexture(bgTextureName);
-    // resourceDepository::removeUnreferencedTextures(); // should revisit what this does
     delete Camera::c;
     delete FocusTracker::ftracker;
 }
@@ -274,7 +272,7 @@ int Scene::_loadScene(lua_State* L) {
     }
     Scene* scene = static_cast<Scene*>(lua_touserdata(L, -1));
     lua_pop(L, 1);
-    resourceDepository::loadScene(L);
+    scene->resources = resourceDepository::loadScene(L);
     lua_pop(L, 1);
     lua_pushnil(L);
     while (lua_next(L, -2))

--- a/Scene.h
+++ b/Scene.h
@@ -2,6 +2,7 @@
 #define SCENE_H
 #include "FocusTracker.h"
 #include "things/FieldPlayer.h"
+#include "resourceDepository.h"
 
 using namespace luaUtils;
 
@@ -17,6 +18,8 @@ struct Scene : public Host {
 
     string sceneName;
     string bgTextureName;
+
+    resourceDepository::SceneResources resources;
 
     map<string, RealThing*> things;
     vector<string> thingsToDestroy;

--- a/components/Sprite.cpp
+++ b/components/Sprite.cpp
@@ -9,8 +9,8 @@ Sprite::Sprite (Point &pos, SpriteData sd) :
     active(false) {
     id = currentID++;
     sprites[id] = this;
-    texture = resourceDepository::getTexture(sd.textureName)->texture;
-    SDL_QueryTexture(texture, NULL, NULL, &sheetWidth, &sheetHeight);
+    texture = resourceDepository::getTexture(sd.textureName);
+    SDL_QueryTexture(texture->texture, NULL, NULL, &sheetWidth, &sheetHeight);
     d.width = sd.width > 0 ? sd.width : sheetWidth;
     d.height = sd.height > 0 ? sd.height : sheetHeight;
     active = true;
@@ -21,11 +21,11 @@ Sprite::Sprite(Sprite &sprite) :
     d(sprite.d),
     alpha(sprite.alpha),
     active(sprite.active),
+    texture(sprite.texture),
     sheetWidth(sprite.sheetWidth),
     sheetHeight(sprite.sheetHeight) {
     id = currentID++;
     sprites[id] = this;
-    texture = resourceDepository::getTexture(d.textureName)->texture;
 }
 
 Sprite::Sprite(Sprite &sprite, Point &pos, string &tN) :
@@ -33,15 +33,14 @@ Sprite::Sprite(Sprite &sprite, Point &pos, string &tN) :
     d(sprite.d),
     alpha(sprite.alpha),
     active(sprite.active),
+    texture(sprite.texture),
     sheetWidth(sprite.sheetWidth),
     sheetHeight(sprite.sheetHeight) {
     id = currentID++;
     sprites[id] = this;
-    texture = resourceDepository::getTexture(d.textureName)->texture;
 }
 
 Sprite::~Sprite() {
-    resourceDepository::releaseTexture(d.textureName);
     sprites.erase(id);
 }
 
@@ -73,13 +72,13 @@ Point Sprite::getScreenPos(Point camPosition) {
 }
 
 void Sprite::render(SDL_Renderer *renderer, Point camPosition) {
-    if (!active || texture == NULL)
+    if (!active || !texture || texture->texture == NULL)
         return;
     Point renderPos = getScreenPos(camPosition);
     SDL_Rect renderRect = { renderPos.x, renderPos.y, d.width * settings.SCALE, d.height * settings.SCALE };
     SDL_Rect sourceRect = { d.sourceX, d.sourceY, d.width, d.height };
-    SDL_SetTextureAlphaMod(texture, alpha);
-    SDL_RenderCopy(renderer, texture, &sourceRect, &renderRect);
+    SDL_SetTextureAlphaMod(texture->texture, alpha);
+    SDL_RenderCopy(renderer, texture->texture, &sourceRect, &renderRect);
 };
 
 void Sprite::getInts(vector<int*> &ints, vector<string> &names) {

--- a/components/Sprite.h
+++ b/components/Sprite.h
@@ -34,7 +34,7 @@ struct Sprite {
     int alpha, sheetHeight, sheetWidth;
     Point &position;
     SpriteData d;
-    SDL_Texture* texture;
+    shared_ptr<Texture> texture;
 
     void divideSheet(int columns, int rows);
     void centerOffset();
@@ -46,7 +46,6 @@ struct Sprite {
 
     static int currentID;
     inline static map<int, Sprite*> sprites;
-    inline static map<string, pair<int, SDL_Texture*>> textures;
     static void renderSprites(SDL_Renderer *renderer, Point camPosition);
 
     static void highlightSprite(Sprite* sprite);

--- a/editor/ThingEditor.cpp
+++ b/editor/ThingEditor.cpp
@@ -219,7 +219,7 @@ int ThingEditor::meat(KeyPresses keysDown) {
 int ThingEditor::addSprite() {
     string input = CommandLine::popInput();
     Sprite* sprite = thing->AddRawSprite(input);
-    if (sprite->texture == NULL) {
+    if (sprite->texture->texture == NULL) {
         delete sprite;
         return 0;
     }

--- a/gui/MenuDisplay.cpp
+++ b/gui/MenuDisplay.cpp
@@ -34,6 +34,7 @@ MenuDisplay::~MenuDisplay() {
     clearLists();
     delete box;
     delete header;
+    delete flavorBox;
 }
 
 void MenuDisplay::buildPages() {

--- a/gui/MenuDisplay.h
+++ b/gui/MenuDisplay.h
@@ -32,7 +32,7 @@ struct MenuDisplay {
     Image* box;
     Image* flavorBox;
 
-    Texture *font = nullptr;
+    shared_ptr<Texture> font;
 
     Point position;
     Text flavorText;

--- a/gui/Phrase.cpp
+++ b/gui/Phrase.cpp
@@ -35,8 +35,8 @@ Phrase::Phrase(const Phrase& ph) :
     gridLimits(ph.gridLimits),
     state(PhrasePhase::standby) {
 
-    font = resourceDepository::getTexture(ph.font->name);
-    speechBubble = resourceDepository::getTexture(ph.speechBubble->name);
+    font = ph.font;
+    speechBubble = ph.speechBubble;
 
     id = "phrase " + to_string(currentID++);
 }

--- a/gui/Phrase.h
+++ b/gui/Phrase.h
@@ -38,8 +38,8 @@ class Phrase {
         string text;
         queue<string> lines, hiddenLines;
 
-        Texture* font;
-        Texture* speechBubble;
+        shared_ptr<Texture> font;
+        shared_ptr<Texture> speechBubble;
 
         Phrase(Point p, Point pixelSize, ScrollType type, string t, Point gL = Point(1000,1000), int pS = 1, int d = 1);
         Phrase(const Phrase& ph);

--- a/gui/Text.h
+++ b/gui/Text.h
@@ -12,7 +12,7 @@ class Text {
         string text;
         int lineLength;
 
-        Texture* font;
+        shared_ptr<Texture> font;
 
         Text() : text(""), lineLength(-1) {
             font = resourceDepository::getTexture("defaultFont");

--- a/main.cpp
+++ b/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char* args[]) {
     lua_getglobal(L, "loadBaseResources");
     if(!luaUtils::CheckLua(L, lua_pcall(L, 0, 1, 0)))
         throw exception();
-    resourceDepository::loadTexturesFromTable(L);
+    resourceDepository::loadTexturesFromTable(L, resourceDepository::pinnedTextures);
     lua_settop(L, 0);
 
     new GameController(L);

--- a/resourceDepository.cpp
+++ b/resourceDepository.cpp
@@ -10,6 +10,11 @@ Texture::Texture(string n, string path) : name(n) {
     SDL_FreeSurface(temp);
 }
 
+Texture::~Texture() {
+    if (texture)
+        SDL_DestroyTexture(texture);
+}
+
 Sfx::Sfx(string n, string path) : name(n) {
     if (name == "") {
         sound = nullptr;
@@ -17,113 +22,76 @@ Sfx::Sfx(string n, string path) : name(n) {
     }
     sound = Mix_LoadWAV(path.c_str());
 }
-Texture* resourceDepository::getTexture(string name) {
-    if(!textures.count(name)) {
-        cout << "Cannot get texture " << name << " that is not loaded!\n";
-        throw exception();
-    }
-    textures[name].first++;
-    return textures[name].second;
+
+Sfx::~Sfx() {
+    if (sound)
+        Mix_FreeChunk(sound);
 }
 
-void resourceDepository::releaseTexture(string name) {
-    if(!textures.count(name)) {
-        cout << "Cannot release texture " << name << " that is not loaded!\n";
-        throw exception();
-    }
-    textures[name].first--;
+shared_ptr<Texture> resourceDepository::getTexture(string name) {
+    if (auto it = textures.find(name); it != textures.end())
+        if (auto tex = it->second.lock())
+            return tex;
+    cout << "Cannot get texture " << name << " that is not loaded!\n";
+    throw exception();
 }
 
-Sfx* resourceDepository::getChunk(string name) {
-    if(!chunks.count(name)) {
-        cout << "Cannot get chunk " << name << " that is not loaded!\n";
-        throw exception();
-    }
-    chunks[name].first++;
-    return chunks[name].second;
+shared_ptr<Sfx> resourceDepository::getChunk(string name) {
+    if (auto it = chunks.find(name); it != chunks.end())
+        if (auto chunk = it->second.lock())
+            return chunk;
+    cout << "Cannot get chunk " << name << " that is not loaded!\n";
+    throw exception();
 }
 
-// Maybe this should take a Sfx pointer
-void resourceDepository::releaseChunk(string name) {
-    if(!chunks.count(name)) {
-        cout << "Cannot release sound chunk " << name << " that is not loaded!\n";
-        throw exception();
-    }
-    chunks[name].first--;
+shared_ptr<Texture> resourceDepository::loadTexture(string name, string path) {
+    if (auto it = textures.find(name); it != textures.end())
+        if (auto existing = it->second.lock())
+            return existing;
+    cout << name << " : " << path << endl;
+    auto tex = make_shared<Texture>(name, path);
+    textures[name] = tex;
+    return tex;
 }
 
-void resourceDepository::loadTexturesFromTable(lua_State *L) {
+void resourceDepository::loadTexturesFromTable(lua_State *L, map<string, shared_ptr<Texture>>& into) {
     lua_pushnil(L);
     while (lua_next(L, -2)) {
         string name = lua_tostring(L, -2);
         string path = lua_tostring(L, -1);
-        loadTexture(name, path);
+        into[name] = loadTexture(name, path);
         lua_pop(L,1);
     }
     lua_pop(L,1);
 }
 
-void resourceDepository::loadTexture(string name, string simplePath) {
-    cout << name << " : " << simplePath << endl;
-    if(!textures.count(name))
-        textures[name] = make_pair(0,new Texture(name, simplePath));
-    else
-        cout << "texture " << name << " is already loaded, skipping\n";
-}
-
-void resourceDepository::loadScene(lua_State *L) {
+resourceDepository::SceneResources resourceDepository::loadScene(lua_State *L) {
+    SceneResources res;
     cout << "LOADING RESOURCES\n";
     if (!luaUtils::GetTableOnStackFromTable(L, "textures")) {
         cout << "no textures found\n";
-        return;
+        return res;
     }
-    loadTexturesFromTable(L);
+    loadTexturesFromTable(L, res.textures);
     if (!luaUtils::GetTableOnStackFromTable(L, "sounds")) {
         cout << "no sounds found\n";
-        return;
+        return res;
     }
     lua_pushnil(L);
     while (lua_next(L, -2)) {
         string name = lua_tostring(L, -2);
         string simplePath = lua_tostring(L, -1);
         string path = "assets/" + simplePath + ".mp3";
-        if(!chunks.count(name))
-            chunks[name] = make_pair(0,new Sfx(name, path));
-        else
-            cout << "sound chunk " << name << " is already loaded, skipping\n";
+        if (auto it = chunks.find(name); it != chunks.end())
+            if (auto existing = it->second.lock())
+                res.chunks[name] = existing;
+        if (!res.chunks.count(name)) {
+            auto chunk = make_shared<Sfx>(name, path);
+            chunks[name] = chunk;
+            res.chunks[name] = chunk;
+        }
         lua_pop(L,1);
     }
     lua_pop(L,1);
-}
-
-void resourceDepository::removeUnreferencedTextures() { // this shits broken
-    map<string, pair<int, Texture*>>::iterator tItr = textures.begin();
-    while (tItr != textures.end()) {
-        string name = tItr->first;
-        int references = tItr->second.first;
-        Texture* texture = tItr->second.second;
-        tItr++;
-        if (references > 0) {
-            cout << "will not destroy texture " << name << " that has " << references << " references!\n";
-            continue;
-        }
-        SDL_DestroyTexture(texture->texture);
-        delete texture;
-        textures.erase(name);
-    }
-
-    map<string, pair<int, Sfx*>>::iterator sItr = chunks.begin();
-    while (sItr != chunks.end()) {
-        string name = sItr->first;
-        int references = sItr->second.first;
-        Sfx* texture = sItr->second.second;
-        sItr++;
-        if (references > 0) {
-            cout << "will not destroy sound chunk " << name << " that has " << references << " references!\n";
-            continue;
-        }
-        Mix_FreeChunk(chunks[name].second->sound);
-        delete chunks[name].second;
-        chunks.erase(name);
-    }
+    return res;
 }

--- a/resourceDepository.h
+++ b/resourceDepository.h
@@ -1,6 +1,8 @@
 #ifndef RESOURCE_DEPOSITORY_H
 #define RESOURCE_DEPOSITORY_H
 #include <map>
+#include <memory>
+#include <vector>
 #include <iostream>
 #include <SDL2/SDL_image.h>
 #include "globals.h"
@@ -9,43 +11,45 @@ using namespace std;
 
 struct Texture {
     Texture(string n, string path);
+    ~Texture();
+    Texture(const Texture&) = delete;
+    Texture& operator=(const Texture&) = delete;
     string name;
-    SDL_Texture* texture;
+    SDL_Texture* texture = nullptr;
 };
 
 
 struct Sfx {
     Sfx(string n, string path);
+    ~Sfx();
+    Sfx(const Sfx&) = delete;
+    Sfx& operator=(const Sfx&) = delete;
     string name;
-    Mix_Chunk* sound;
+    Mix_Chunk* sound = nullptr;
 };
 
 
 namespace resourceDepository {
-    inline map<string, pair<int, Texture*>> textures;
-    inline map<string, pair<int, Sfx*>> chunks;
+    inline map<string, weak_ptr<Texture>> textures;
+    inline map<string, weak_ptr<Sfx>> chunks;
 
-    void loadTexturesFromTable(lua_State *L);
-    void loadScene(lua_State *L);
-    void removeUnreferencedTextures();
+    inline map<string, shared_ptr<Texture>> pinnedTextures;
+    struct SceneResources {
+        map<string, shared_ptr<Texture>> textures;
+        map<string, shared_ptr<Sfx>> chunks;
+    };
 
-    // Maybe have prefetch functions that take a list of names and loads all of them, and releases them after
-    void loadTexture(string name, string simplePath);
-    Texture* getTexture(string name);
-    void releaseTexture(string name);
+    shared_ptr<Texture> loadTexture(string name, string path);
+    void loadTexturesFromTable(lua_State *L, map<string, shared_ptr<Texture>>& into);
+    SceneResources loadScene(lua_State *L);
 
-    Sfx* getChunk(string name);
-    void releaseChunk(string name);
+    shared_ptr<Texture> getTexture(string name);
+    shared_ptr<Sfx> getChunk(string name);
 };
 
 struct Image {
-    Image(string textureName, SDL_Rect sR) : sourceRect(sR) {
-        texture = resourceDepository::getTexture(textureName);
-    }
-    ~Image() {
-        resourceDepository::releaseTexture(texture->name);
-    }
-    Texture* texture;
+    Image(string textureName, SDL_Rect sR) : sourceRect(sR), texture(resourceDepository::getTexture(textureName)) {}
+    shared_ptr<Texture> texture;
     SDL_Rect sourceRect;
 };
 


### PR DESCRIPTION
- Resource Depository stores cache of weak pointers as a map
- Scene owns a shared pointer for every resource in the Scene from load until unload, so resources never re-load
- Consumers of sprites and sounds also own a shared pointer to their resources
- No more explicit deallocating