### PR TITLE
Fix obstruction bug, allow opening to not disable colliders

### DIFF
--- a/games/barycenter/scenes/burg/setup.lua
+++ b/games/barycenter/scenes/burg/setup.lua
@@ -317,6 +317,7 @@ local thingDefs = {
                     open = {
                         type = "open",
                         triggerDelay = 30,
+                        disableCollidersOnOpen = true,
                         portal = {
                             relativeX = -25,
                             relativeY = -131,

--- a/games/barycenter/scenes/testSceneTwo/setup.lua
+++ b/games/barycenter/scenes/testSceneTwo/setup.lua
@@ -316,9 +316,10 @@ local thingDefs = {
                     open = {
                         type = "open",
                         triggerDelay = 30,
-                        portal = { -- This portal is broken - after teleporting, obstrution collisions don't detect and portalling backwords crashes.
-                            relativeX = 0,
-                            relativeY = -5,
+                        disableCollidersOnOpen = true,
+                        portal = {
+                            relativeX = 30,
+                            relativeY = 90,
                             newLayer = 0,
                             newScene = "burg"
                         },

--- a/scripts/standardEvents.lua
+++ b/scripts/standardEvents.lua
@@ -112,16 +112,17 @@ local function open(hostThing, args)
         }}, args.eventName, hostThing)
         coroutine.yield()
     end
-    _newTask({
-        {
-            type = "setActiveSprites",
-            sprites =  { 0 }
-        },
-        {
+    local openSubtasks = {{
+        type = "setActiveSprites",
+        sprites =  { 0 }
+    }}
+    if disableCollidersOnOpen == true then
+        openSubtasks[1] = {
             type = "disableColliders",
             obstructions = true
         }
-    }, args.eventName, hostThing)
+    end
+    _newTask(openSubtasks, args.eventName, hostThing)
     if args["receiveItem"] then
         coroutine.yield()
         __receiveItem(hostThing, args)

--- a/things/RealThing.cpp
+++ b/things/RealThing.cpp
@@ -301,10 +301,15 @@ void RealThing::shiftLayer(int newLayer) {
     for (auto s : sprites)
         s->d.layer = newLayer;
 
-    Obstruction* ob = obstructions[oldLayer];
+    if (newLayer == oldLayer)
+        return;
+    auto it = obstructions.find(oldLayer);
+    if (it == obstructions.end())
+        return;
+    Obstruction* ob = it->second;
     ob->layer = newLayer;
-    obstructions[ob->layer] = ob;
-    obstructions.erase(oldLayer);
+    obstructions.erase(it);
+    obstructions[newLayer] = ob;
 }
 
 Interactable* RealThing::addInteractable(string iName, vector<Ray> rays, int layer) {


### PR DESCRIPTION
- Don't wipe obstructions if you're switching to the same layer you're were already on
- Pass `disableCollidersOnOpen` into `open` instead of always disabling them